### PR TITLE
feat: add comprehensive tests, placeholder validation, and stricter parsing rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "templatia"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "chumsky",
  "templatia-derive",
@@ -256,7 +256,7 @@ dependencies = [
 
 [[package]]
 name = "templatia-derive"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.0.1"
+version = "0.0.2"
 authors = ["SHIMA0111<shima@little-tabby.com>"]
 license = "MIT or Apache-2.0"
 readme = "README.md"

--- a/templatia-derive/src/generator.rs
+++ b/templatia-derive/src/generator.rs
@@ -1,6 +1,8 @@
 use crate::parser::TemplateSegments;
 use quote::quote;
 use std::collections::{HashMap, HashSet};
+use crate::utils::is_allowed_consecutive_allowed_type;
+use crate::validator::validate_template_safety;
 
 pub(crate) fn generate_str_parser(
     struct_name: &syn::Ident,
@@ -29,10 +31,20 @@ pub(crate) fn generate_str_parser(
         }
     }
 
+    if let Err(e) = validate_template_safety(segments, all_fields) {
+        let error = syn::Error::new(
+            proc_macro2::Span::call_site(),
+            format!("{}: {}", struct_name.to_string(), e),
+        );
+
+        return error.to_compile_error().into();
+    }
+
     let mut parsers = segments.iter().peekable();
     let mut generated_full_parser = quote! { ::templatia::__private::chumsky::prelude::empty() };
     let mut parser_count = 0;
     let mut latest_segment_was_literal = false;
+    let mut first_placeholder_was_parsed = false;
 
     while let Some(segment) = parsers.next() {
         match segment {
@@ -74,7 +86,7 @@ pub(crate) fn generate_str_parser(
                 if parser_count == 0 {
                     generated_full_parser = field_parser;
                 } else {
-                    if latest_segment_was_literal && parser_count == 1 {
+                    if latest_segment_was_literal && !first_placeholder_was_parsed {
                         generated_full_parser =
                             quote! { #generated_full_parser.ignore_then(#field_parser) }
                     } else {
@@ -82,6 +94,7 @@ pub(crate) fn generate_str_parser(
                             quote! { #generated_full_parser.then(#field_parser) }
                     }
                 }
+                first_placeholder_was_parsed = true;
                 latest_segment_was_literal = false;
             }
         }
@@ -166,8 +179,18 @@ fn generate_field_parser(
                 .to_slice()
         }
     } else {
-        quote! {
-            ::templatia::__private::chumsky::prelude::any::<&str, ::templatia::__private::chumsky::extra::Err<::templatia::__private::chumsky::error::Rich<char>>>().repeated().to_slice()
+        if is_allowed_consecutive_allowed_type(field_type) {
+            quote! {
+                ::templatia::__private::chumsky::prelude::any::<&str, ::templatia::__private::chumsky::extra::Err<::templatia::__private::chumsky::error::Rich<char>>>()
+                    .map(|c| c.to_string())
+                    .to_slice()
+            }
+        } else {
+            quote! {
+                ::templatia::__private::chumsky::prelude::any::<&str, ::templatia::__private::chumsky::extra::Err<::templatia::__private::chumsky::error::Rich<char>>>()
+                    .repeated()
+                    .to_slice()
+            }
         }
     };
 

--- a/templatia-derive/src/lib.rs
+++ b/templatia-derive/src/lib.rs
@@ -27,6 +27,8 @@
 
 mod generator;
 mod parser;
+mod validator;
+mod utils;
 
 use crate::generator::generate_str_parser;
 use crate::parser::{TemplateSegments, parse_template};

--- a/templatia-derive/src/parser.rs
+++ b/templatia-derive/src/parser.rs
@@ -11,9 +11,15 @@ pub(crate) fn parse_template(template: &'_ str) -> Result<Vec<TemplateSegments<'
     while let Some((i, c)) = chars.next() {
         match c {
             '{' => {
-                if let Some(&(_, next_char)) = chars.peek() {
+                if let Some(&(next_idx, next_char)) = chars.peek() {
                     // if the next char is a `{`, it means escaped brace, so it shouldn't be treated as a placeholder.
                     if next_char == '{' {
+                        // In escaped brace displayed as `{` in literal, not should be `{{`.
+                        if next_idx > last_end {
+                            segments.push(TemplateSegments::Literal(&template[last_end..next_idx]));
+                            last_end = next_idx + 1;
+                        }
+
                         chars.next();
                         continue;
                     }
@@ -53,9 +59,15 @@ pub(crate) fn parse_template(template: &'_ str) -> Result<Vec<TemplateSegments<'
                 }
             }
             '}' => {
-                if let Some(&(_, next_char)) = chars.peek() {
+                if let Some(&(next_idx, next_char)) = chars.peek() {
                     // if the next char is a `}`, it means escaped brace, so it shouldn't be treated as an end brace.
                     if next_char == '}' {
+                        // In escaped brace displayed as `}` in literal, not should be `}}`.
+                        if next_idx > last_end {
+                            segments.push(TemplateSegments::Literal(&template[last_end..next_idx]));
+                            last_end = next_idx + 1;
+                        }
+
                         chars.next();
                         continue;
                     }

--- a/templatia-derive/src/utils.rs
+++ b/templatia-derive/src/utils.rs
@@ -1,0 +1,36 @@
+pub(crate) const CONSECUTIVE_PLACEHOLDER_ALLOWED_TYPE: [&str; 1] = ["char"];
+
+pub(crate) fn is_allowed_consecutive_allowed_type(field_type: &syn::Type) -> bool {
+    match field_type {
+        syn::Type::Path(path) => {
+            if let Some(ident) = &path.path.get_ident() {
+                CONSECUTIVE_PLACEHOLDER_ALLOWED_TYPE.contains(&ident.to_string().as_str())
+            } else {
+                false
+            }
+        },
+        _ => false,
+    }
+}
+
+pub(crate) fn get_field_type_by_name<'a>(field_name: &str, all_fields: &'a [syn::Field]) -> Option<&'a syn::Type> {
+    all_fields
+        .iter()
+        .find(|field| {
+            field.ident.as_ref().map(|ident| ident.to_string()) == Some(field_name.to_string())
+        })
+        .map(|field| &field.ty)
+}
+
+pub(crate) fn get_type_name(ty: &syn::Type) -> String {
+    match ty {
+        syn::Type::Path(path) => {
+            if let Some(ident) = &path.path.get_ident() {
+                ident.to_string()
+            } else {
+                "unknown_type".to_string()
+            }
+        },
+        _ => "unknown_type".to_string(),
+    }
+}

--- a/templatia-derive/src/validator.rs
+++ b/templatia-derive/src/validator.rs
@@ -1,0 +1,32 @@
+use crate::parser::TemplateSegments;
+use crate::utils::{get_field_type_by_name, get_type_name, is_allowed_consecutive_allowed_type, CONSECUTIVE_PLACEHOLDER_ALLOWED_TYPE};
+
+pub(crate) fn validate_template_safety(
+    segments: &[TemplateSegments],
+    all_fields: &[syn::Field],
+) -> Result<(), String> {
+    for window in segments.windows(2) {
+        if let [TemplateSegments::Placeholder(first), TemplateSegments::Placeholder(second)] = window {
+            let first_type = get_field_type_by_name(first, all_fields);
+
+            let (allowed_consecutive, first_type_name) = match first_type {
+                Some(first_ty) => {
+                    (is_allowed_consecutive_allowed_type(first_ty), get_type_name(first_ty))
+                },
+                _ => (false, "unknown_type".to_string()),
+            };
+
+            if !allowed_consecutive {
+                return Err(
+                    format!(
+                        "Placeholder \"{0}\" and \"{1}\" is consecutive. These are ambiguous to parsing.\
+                        \n\"{0}\" is `{2}` type data. Consecutive allows only: [{3}]",
+                        first, second, first_type_name, CONSECUTIVE_PLACEHOLDER_ALLOWED_TYPE.join(", ")
+                    )
+                )
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/templatia-derive/tests/compile_fail/missing_field.rs
+++ b/templatia-derive/tests/compile_fail/missing_field.rs
@@ -1,0 +1,5 @@
+use templatia::Template;
+
+#[derive(Template)]
+#[templatia(template = "host={host}, port={port}, user={username}")]
+struct DbCfg { host: String, port: u16 }

--- a/templatia-derive/tests/comprehensive_tests.rs
+++ b/templatia-derive/tests/comprehensive_tests.rs
@@ -1,0 +1,714 @@
+use templatia::{Template, TemplateError};
+// Tests follow AGENTS.md policy. They express intended behavior from docs.
+
+/// Tests for default template behavior and edge cases
+mod default_template_tests {
+    use super::*;
+
+    #[test]
+    fn default_template_single_field() {
+        #[derive(Template, Debug, PartialEq)]
+        struct SingleField {
+            name: String,
+        }
+
+        let single = SingleField {
+            name: "test".into(),
+        };
+        let template = single.to_string();
+        assert_eq!(template, "name = test");
+
+        let parsed = SingleField::from_string(&template).unwrap();
+        assert_eq!(parsed, single);
+    }
+
+    #[test]
+    fn default_template_multiple_fields_preserves_order() {
+        #[derive(Template, Debug, PartialEq)]
+        struct MultiField {
+            alpha: String,
+            beta: u32,
+            gamma: bool,
+        }
+
+        let multi = MultiField {
+            alpha: "first".into(),
+            beta: 42,
+            gamma: true,
+        };
+        let template = multi.to_string();
+        assert_eq!(template, "alpha = first\nbeta = 42\ngamma = true");
+
+        let parsed = MultiField::from_string(&template).unwrap();
+        assert_eq!(parsed, multi);
+    }
+
+    #[test]
+    fn default_template_numeric_types() {
+        #[derive(Template, Debug, PartialEq)]
+        struct NumericTypes {
+            byte_val: u8,
+            short_val: u16,
+            int_val: u32,
+            long_val: u64,
+            signed_val: i32,
+            float_val: f32,
+            double_val: f64,
+        }
+
+        let nums = NumericTypes {
+            byte_val: 255,
+            short_val: 65535,
+            int_val: 4294967295,
+            long_val: 18446744073709551615,
+            signed_val: -2147483648,
+            float_val: std::f32::consts::PI,
+            double_val: std::f64::consts::E,
+        };
+
+        let template = nums.to_string();
+        let parsed = NumericTypes::from_string(&template).unwrap();
+        assert_eq!(parsed, nums);
+    }
+
+    #[test]
+    fn default_template_boolean_values() {
+        #[derive(Template, Debug, PartialEq)]
+        struct BoolValues {
+            flag_true: bool,
+            flag_false: bool,
+        }
+
+        let bools = BoolValues {
+            flag_true: true,
+            flag_false: false,
+        };
+
+        let template = bools.to_string();
+        assert_eq!(template, "flag_true = true\nflag_false = false");
+
+        let parsed = BoolValues::from_string(&template).unwrap();
+        assert_eq!(parsed, bools);
+    }
+
+    #[test]
+    fn default_template_empty_string() {
+        #[derive(Template, Debug, PartialEq)]
+        struct EmptyString {
+            empty: String,
+            normal: String,
+        }
+
+        let empty_str = EmptyString {
+            empty: "".into(),
+            normal: "content".into(),
+        };
+
+        let template = empty_str.to_string();
+        assert_eq!(template, "empty = \nnormal = content");
+
+        let parsed = EmptyString::from_string(&template).unwrap();
+        assert_eq!(parsed, empty_str);
+    }
+}
+
+/// Tests for custom template behavior and edge cases
+mod custom_template_tests {
+    use super::*;
+
+    #[test]
+    fn custom_template_complex_format() {
+        #[derive(Template, Debug, PartialEq)]
+        #[templatia(template = "Server: {host} | Port: {port} | DB: {database}")]
+        struct ComplexFormat {
+            host: String,
+            port: u16,
+            database: String,
+        }
+
+        let config = ComplexFormat {
+            host: "db.example.com".into(),
+            port: 5432,
+            database: "production".into(),
+        };
+
+        let template = config.to_string();
+        assert_eq!(template, "Server: db.example.com | Port: 5432 | DB: production");
+
+        let parsed = ComplexFormat::from_string(&template).unwrap();
+        assert_eq!(parsed, config);
+    }
+
+    #[test]
+    fn custom_template_url_format() {
+        #[derive(Template, Debug, PartialEq)]
+        #[templatia(template = "https://{host}:{port}/{path}?token={token}")]
+        struct UrlFormat {
+            host: String,
+            port: u16,
+            path: String,
+            token: String,
+        }
+
+        let url = UrlFormat {
+            host: "api.example.com".into(),
+            port: 443,
+            path: "v1/data".into(),
+            token: "abc123".into(),
+        };
+
+        let template = url.to_string();
+        assert_eq!(template, "https://api.example.com:443/v1/data?token=abc123");
+
+        let parsed = UrlFormat::from_string(&template).unwrap();
+        assert_eq!(parsed, url);
+    }
+
+    #[test]
+    fn custom_template_json_like_format() {
+        #[derive(Template, Debug, PartialEq)]
+        #[templatia(template = r#"{{"name": "{name}", "age": {age}, "active": {active}}}"#)]
+        struct JsonLike {
+            name: String,
+            age: u32,
+            active: bool,
+        }
+
+        let person = JsonLike {
+            name: "Alice".into(),
+            age: 30,
+            active: true,
+        };
+
+        let template = person.to_string();
+        assert_eq!(template, r#"{"name": "Alice", "age": 30, "active": true}"#);
+
+        let parsed = JsonLike::from_string(&template).unwrap();
+        assert_eq!(parsed, person);
+    }
+
+    #[test]
+    fn custom_template_with_special_characters() {
+        #[derive(Template, Debug, PartialEq)]
+        #[templatia(template = "User: {name}\nEmail: {email}\nNotes: {notes}")]
+        struct SpecialChars {
+            name: String,
+            email: String,
+            notes: String,
+        }
+
+        let user = SpecialChars {
+            name: "John Doe".into(),
+            email: "john@example.com".into(),
+            notes: "Test notes with symbols: @#$%^&*()".into(),
+        };
+
+        let template = user.to_string();
+        let parsed = SpecialChars::from_string(&template).unwrap();
+        assert_eq!(parsed, user);
+    }
+
+    #[test]
+    fn custom_template_minimal_format() {
+        #[derive(Template, Debug, PartialEq)]
+        #[templatia(template = "{value}")]
+        struct Minimal {
+            value: String,
+        }
+
+        let minimal = Minimal {
+            value: "just_this".into(),
+        };
+
+        let template = minimal.to_string();
+        assert_eq!(template, "just_this");
+
+        let parsed = Minimal::from_string(&template).unwrap();
+        assert_eq!(parsed, minimal);
+    }
+}
+
+/// Tests for duplicate placeholder behavior
+mod duplicate_placeholder_tests {
+    use super::*;
+
+    #[test]
+    fn duplicate_placeholders_consistent_values() {
+        #[derive(Template, Debug, PartialEq)]
+        #[templatia(template = "Hello {name}! Welcome back, {name}!")]
+        struct Greeting {
+            name: String,
+        }
+
+        let greeting = Greeting {
+            name: "Alice".into(),
+        };
+
+        let template = greeting.to_string();
+        assert_eq!(template, "Hello Alice! Welcome back, Alice!");
+
+        let parsed = Greeting::from_string(&template).unwrap();
+        assert_eq!(parsed, greeting);
+    }
+
+    #[test]
+    fn duplicate_placeholders_many_occurrences() {
+        #[derive(Template, Debug, PartialEq)]
+        #[templatia(template = "{id}-{id}-{id}-{id}")]
+        struct MultiId {
+            id: u32,
+        }
+
+        let multi = MultiId { id: 12345 };
+
+        let template = multi.to_string();
+        assert_eq!(template, "12345-12345-12345-12345");
+
+        let parsed = MultiId::from_string(&template).unwrap();
+        assert_eq!(parsed, multi);
+    }
+
+    #[test]
+    fn duplicate_placeholders_inconsistent_values_error() {
+        #[derive(Template, Debug, PartialEq)]
+        #[templatia(template = "first={name}, second={name}")]
+        struct Inconsistent {
+            name: String,
+        }
+
+        let result = Inconsistent::from_string("first=alice, second=bob");
+        
+        match result {
+            Err(TemplateError::InconsistentValues {
+                placeholder,
+                first_value,
+                second_value,
+            }) => {
+                assert_eq!(placeholder, "name");
+                assert_eq!(first_value, "alice");
+                assert_eq!(second_value, "bob");
+            }
+            other => panic!("Expected InconsistentValues error, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn duplicate_placeholders_numeric_inconsistency() {
+        #[derive(Template, Debug, PartialEq)]
+        #[templatia(template = "port1={port} port2={port}")]
+        struct NumericInconsistent {
+            port: u16,
+        }
+
+        let result = NumericInconsistent::from_string("port1=8080 port2=9090");
+        
+        match result {
+            Err(TemplateError::InconsistentValues {
+                placeholder,
+                first_value,
+                second_value,
+            }) => {
+                assert_eq!(placeholder, "port");
+                assert_eq!(first_value, "8080");
+                assert_eq!(second_value, "9090");
+            }
+            other => panic!("Expected InconsistentValues error, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn duplicate_placeholders_mixed_with_unique() {
+        #[derive(Template, Debug, PartialEq)]
+        #[templatia(template = "{env}-{service}-{env}-{version}")]
+        struct MixedDuplicates {
+            env: String,
+            service: String,
+            version: String,
+        }
+
+        let mixed = MixedDuplicates {
+            env: "prod".into(),
+            service: "api".into(),
+            version: "v1.0".into(),
+        };
+
+        let template = mixed.to_string();
+        assert_eq!(template, "prod-api-prod-v1.0");
+
+        let parsed = MixedDuplicates::from_string(&template).unwrap();
+        assert_eq!(parsed, mixed);
+    }
+}
+
+/// Tests for error handling and edge cases
+mod error_handling_tests {
+    use super::*;
+
+    #[test]
+    fn parse_error_invalid_number() {
+        #[derive(Template, Debug, PartialEq)]
+        #[templatia(template = "port={port}")]
+        struct PortConfig {
+            port: u16,
+        }
+
+        let result = PortConfig::from_string("port=not_a_number");
+        
+        match result {
+            Err(TemplateError::Parse(msg)) => {
+                assert!(msg.contains("Failed to parse field \"port\""));
+            }
+            other => panic!("Expected Parse error, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_error_invalid_boolean() {
+        #[derive(Template, Debug, PartialEq)]
+        #[templatia(template = "enabled={enabled}")]
+        struct BoolConfig {
+            enabled: bool,
+        }
+
+        let result = BoolConfig::from_string("enabled=maybe");
+        
+        match result {
+            Err(TemplateError::Parse(msg)) => {
+                assert!(msg.contains("Failed to parse field \"enabled\""));
+            }
+            other => panic!("Expected Parse error, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_error_number_overflow() {
+        #[derive(Template, Debug, PartialEq)]
+        #[templatia(template = "value={value}")]
+        struct OverflowTest {
+            value: u8,
+        }
+
+        let result = OverflowTest::from_string("value=256");
+        
+        match result {
+            Err(TemplateError::Parse(_)) => {
+                // Expected - overflow should cause parse error
+            }
+            other => panic!("Expected Parse error for overflow, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_error_negative_unsigned() {
+        #[derive(Template, Debug, PartialEq)]
+        #[templatia(template = "count={count}")]
+        struct UnsignedTest {
+            count: u32,
+        }
+
+        let result = UnsignedTest::from_string("count=-1");
+        
+        match result {
+            Err(TemplateError::Parse(_)) => {
+                // Expected - negative value for unsigned type should fail
+            }
+            other => panic!("Expected Parse error for negative unsigned, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_error_malformed_template() {
+        #[derive(Template, Debug, PartialEq)]
+        #[templatia(template = "host={host}:{port}")]
+        struct HostPort {
+            host: String,
+            port: u16,
+        }
+
+        // Missing colon separator
+        let result = HostPort::from_string("host=localhost 8080");
+        
+        match result {
+            Err(TemplateError::Parse(_)) => {
+                // Expected - template doesn't match expected format
+            }
+            other => panic!("Expected Parse error for malformed template, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_error_partial_template_match() {
+        #[derive(Template, Debug, PartialEq)]
+        #[templatia(template = "prefix_{value}_suffix")]
+        struct PrefixSuffix {
+            value: String,
+        }
+
+        // Missing suffix
+        let result = PrefixSuffix::from_string("prefix_test");
+        
+        match result {
+            Err(TemplateError::Parse(_)) => {
+                // Expected - incomplete template match
+            }
+            other => panic!("Expected Parse error for partial match, got: {other:?}"),
+        }
+    }
+}
+
+/// Tests for type constraint edge cases
+mod type_constraint_tests {
+    use super::*;
+
+    #[test]
+    fn floating_point_precision() {
+        #[derive(Template, Debug)]
+        #[templatia(template = "value={value}")]
+        struct FloatTest {
+            value: f64,
+        }
+
+        let original = FloatTest { value: std::f64::consts::PI };
+        let template = original.to_string();
+        let parsed = FloatTest::from_string(&template).unwrap();
+        
+        // Allow for floating point precision differences
+        assert!((parsed.value - original.value).abs() < 1e-10);
+    }
+
+    #[test]
+    fn extreme_numeric_values() {
+        #[derive(Template, Debug, PartialEq)]
+        #[templatia(template = "max={max_val}, min={min_val}")]
+        struct ExtremeValues {
+            max_val: i64,
+            min_val: i64,
+        }
+
+        let extreme = ExtremeValues {
+            max_val: i64::MAX,
+            min_val: i64::MIN,
+        };
+
+        let template = extreme.to_string();
+        let parsed = ExtremeValues::from_string(&template).unwrap();
+        assert_eq!(parsed, extreme);
+    }
+
+    #[test]
+    fn zero_values() {
+        #[derive(Template, Debug, PartialEq)]
+        #[templatia(template = "int={int_zero}, float={float_zero}")]
+        struct ZeroValues {
+            int_zero: i32,
+            float_zero: f64,
+        }
+
+        let zeros = ZeroValues {
+            int_zero: 0,
+            float_zero: 0.0,
+        };
+
+        let template = zeros.to_string();
+        let parsed = ZeroValues::from_string(&template).unwrap();
+        assert_eq!(parsed, zeros);
+    }
+
+    #[test]
+    fn string_with_whitespace() {
+        #[derive(Template, Debug, PartialEq)]
+        #[templatia(template = "name={name}")]
+        struct WhitespaceTest {
+            name: String,
+        }
+
+        let whitespace = WhitespaceTest {
+            name: "  spaced  name  ".into(),
+        };
+
+        let template = whitespace.to_string();
+        let parsed = WhitespaceTest::from_string(&template).unwrap();
+        assert_eq!(parsed, whitespace);
+    }
+
+    #[test]
+    fn string_with_newlines() {
+        #[derive(Template, Debug, PartialEq)]
+        #[templatia(template = "content={content}")]
+        struct NewlineTest {
+            content: String,
+        }
+
+        let multiline = NewlineTest {
+            content: "line1\nline2\nline3".into(),
+        };
+
+        let template = multiline.to_string();
+        let parsed = NewlineTest::from_string(&template).unwrap();
+        assert_eq!(parsed, multiline);
+    }
+}
+
+/// Tests for field ordering and combinations
+mod field_combination_tests {
+    use super::*;
+
+    #[test]
+    fn many_fields_default_template() {
+        #[derive(Template, Debug, PartialEq)]
+        struct ManyFields {
+            field_a: String,
+            field_b: u32,
+            field_c: bool,
+            field_d: f64,
+            field_e: i16,
+            field_f: String,
+        }
+
+        let many = ManyFields {
+            field_a: "alpha".into(),
+            field_b: 42,
+            field_c: true,
+            field_d: 3.14,
+            field_e: -123,
+            field_f: "omega".into(),
+        };
+
+        let template = many.to_string();
+        let parsed = ManyFields::from_string(&template).unwrap();
+        assert_eq!(parsed, many);
+    }
+
+    #[test]
+    fn mixed_field_order_in_custom_template() {
+        #[derive(Template, Debug, PartialEq)]
+        #[templatia(template = "{c}-{a}-{b}")]
+        struct MixedOrder {
+            a: String,
+            b: u32,
+            c: bool,
+        }
+
+        let mixed = MixedOrder {
+            a: "middle".into(),
+            b: 999,
+            c: false,
+        };
+
+        let template = mixed.to_string();
+        assert_eq!(template, "false-middle-999");
+
+        let parsed = MixedOrder::from_string(&template).unwrap();
+        assert_eq!(parsed, mixed);
+    }
+
+    #[test]
+    fn single_field_repeated_many_times() {
+        #[derive(Template, Debug, PartialEq)]
+        #[templatia(template = "{x}{x}{x}{x}{x}{x}{x}{x}")]
+        struct RepeatedField {
+            x: char,
+        }
+
+        let repeated = RepeatedField { x: 'A' };
+
+        let template = repeated.to_string();
+        assert_eq!(template, "AAAAAAAA");
+
+        let parsed = RepeatedField::from_string(&template).unwrap();
+        assert_eq!(parsed, repeated);
+    }
+}
+
+/// Tests for round-trip consistency
+mod roundtrip_tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_consistency_default_template() {
+        #[derive(Template, Debug, PartialEq)]
+        struct RoundtripTest {
+            name: String,
+            count: u32,
+            enabled: bool,
+        }
+
+        let original = RoundtripTest {
+            name: "test_data".into(),
+            count: 100,
+            enabled: true,
+        };
+
+        // First round-trip
+        let template1 = original.to_string();
+        let parsed1 = RoundtripTest::from_string(&template1).unwrap();
+        assert_eq!(parsed1, original);
+
+        // Second round-trip
+        let template2 = parsed1.to_string();
+        let parsed2 = RoundtripTest::from_string(&template2).unwrap();
+        assert_eq!(parsed2, original);
+
+        // Templates should be identical
+        assert_eq!(template1, template2);
+    }
+
+    #[test]
+    fn roundtrip_consistency_custom_template() {
+        #[derive(Template, Debug, PartialEq, Clone)]
+        #[templatia(template = "Config[{name}]={value}")]
+        struct CustomRoundtrip {
+            name: String,
+            value: String,
+        }
+
+        let original = CustomRoundtrip {
+            name: "database_url".into(),
+            value: "postgres://localhost:5432/mydb".into(),
+        };
+
+        // Multiple round-trips
+        let mut current = original.clone();
+        for _ in 0..5 {
+            let template = current.to_string();
+            current = CustomRoundtrip::from_string(&template).unwrap();
+        }
+
+        assert_eq!(current, original);
+    }
+
+    #[test]
+    fn roundtrip_with_edge_case_values() {
+        #[derive(Template, Debug, PartialEq)]
+        #[templatia(template = "'{text}' #{number}")]
+        struct EdgeCaseRoundtrip {
+            text: String,
+            number: i32,
+        }
+
+        let edge_cases = vec![
+            EdgeCaseRoundtrip {
+                text: "".into(),
+                number: 0,
+            },
+            EdgeCaseRoundtrip {
+                text: "single".into(),
+                number: -1,
+            },
+            EdgeCaseRoundtrip {
+                text: "with spaces and symbols: @#$%".into(),
+                number: i32::MAX,
+            },
+            EdgeCaseRoundtrip {
+                text: "unicode: 🦀 Rust 🚀".into(),
+                number: i32::MIN,
+            },
+        ];
+
+        for original in edge_cases {
+            let template = original.to_string();
+            let parsed = EdgeCaseRoundtrip::from_string(&template).unwrap();
+            assert_eq!(parsed, original, "Failed roundtrip for: {:?}", original);
+        }
+    }
+}

--- a/templatia/Cargo.toml
+++ b/templatia/Cargo.toml
@@ -16,7 +16,7 @@ documentation = { workspace = true }
 [dependencies]
 thiserror = "2"
 
-templatia-derive = { version = "0.0.1", path = "../templatia-derive", optional = true }
+templatia-derive = { version = "0.0.2", path = "../templatia-derive", optional = true }
 chumsky = { version = "0.11", optional = true }
 
 [features]

--- a/templatia/tests/manual_implementations.rs
+++ b/templatia/tests/manual_implementations.rs
@@ -1,0 +1,398 @@
+use templatia::{Template, TemplateError};
+// Tests follow AGENTS.md policy. They express intended behavior from docs.
+
+/// Tests for manual Template implementations as shown in documentation
+mod manual_implementation_tests {
+    use super::*;
+
+    /// Point tuple struct manual implementation from docs
+    struct Point(i32, i32);
+
+    impl Template for Point {
+        type Error = TemplateError;
+        type Struct = Point;
+
+        fn to_string(&self) -> String {
+            format!("({}, {})", self.0, self.1)
+        }
+
+        fn from_string(s: &str) -> Result<Self::Struct, Self::Error> {
+            if !s.starts_with('(') || !s.ends_with(')') {
+                return Err(TemplateError::Parse("Expected format: (x, y)".to_string()));
+            }
+            
+            let inner = &s[1..s.len()-1];
+            let parts: Vec<&str> = inner.split(", ").collect();
+            
+            if parts.len() != 2 {
+                return Err(TemplateError::Parse("Expected two comma-separated values".to_string()));
+            }
+            
+            let x = parts[0].parse().map_err(|_|
+                TemplateError::Parse("Failed to parse x coordinate".to_string()))?;
+            let y = parts[1].parse().map_err(|_|
+                TemplateError::Parse("Failed to parse y coordinate".to_string()))?;
+            
+            Ok(Point(x, y))
+        }
+    }
+
+    #[test]
+    fn point_tuple_struct_implementation() {
+        let point = Point(10, 20);
+        assert_eq!(point.to_string(), "(10, 20)");
+
+        let parsed = Point::from_string("(5, 15)").unwrap();
+        assert_eq!(parsed.0, 5);
+        assert_eq!(parsed.1, 15);
+    }
+
+    #[test]
+    fn point_tuple_struct_roundtrip() {
+        let original = Point(-100, 200);
+        let template = original.to_string();
+        let parsed = Point::from_string(&template).unwrap();
+        assert_eq!(parsed.0, original.0);
+        assert_eq!(parsed.1, original.1);
+    }
+
+    #[test]
+    fn point_tuple_struct_parse_errors() {
+        // Missing parentheses
+        let result = Point::from_string("10, 20");
+        assert!(matches!(result, Err(TemplateError::Parse(_))));
+
+        // Wrong number of values
+        let result = Point::from_string("(10, 20, 30)");
+        assert!(matches!(result, Err(TemplateError::Parse(_))));
+
+        // Invalid numbers
+        let result = Point::from_string("(abc, 20)");
+        assert!(matches!(result, Err(TemplateError::Parse(_))));
+    }
+
+    /// ServerConfig manual implementation from docs
+    struct ServerConfig {
+        name: String,
+        port: u16,
+    }
+
+    impl Template for ServerConfig {
+        type Error = TemplateError;
+        type Struct = ServerConfig;
+
+        fn to_string(&self) -> String {
+            format!("server={},port={}", self.name, self.port)
+        }
+
+        fn from_string(s: &str) -> Result<Self::Struct, Self::Error> {
+            let parts: Vec<&str> = s.split(',').collect();
+            if parts.len() != 2 {
+                return Err(TemplateError::Parse("Expected format: server=name,port=number".to_string()));
+            }
+
+            let name = parts[0].strip_prefix("server=")
+                .ok_or_else(|| TemplateError::Parse("Missing server= prefix".to_string()))?
+                .to_string();
+                
+            let port_str = parts[1].strip_prefix("port=")
+                .ok_or_else(|| TemplateError::Parse("Missing port= prefix".to_string()))?;
+                
+            let port = port_str.parse::<u16>()
+                .map_err(|_| TemplateError::Parse("Invalid port number".to_string()))?;
+
+            Ok(ServerConfig { name, port })
+        }
+    }
+
+    #[test]
+    fn server_config_manual_implementation() {
+        let config = ServerConfig { name: "web01".to_string(), port: 8080 };
+        let template = config.to_string();
+        assert_eq!(template, "server=web01,port=8080");
+
+        let parsed = ServerConfig::from_string(&template).unwrap();
+        assert_eq!(parsed.name, "web01");
+        assert_eq!(parsed.port, 8080);
+    }
+
+    #[test]
+    fn server_config_parse_errors() {
+        // Wrong format
+        let result = ServerConfig::from_string("web01:8080");
+        assert!(matches!(result, Err(TemplateError::Parse(_))));
+
+        // Missing server= prefix
+        let result = ServerConfig::from_string("web01,port=8080");
+        assert!(matches!(result, Err(TemplateError::Parse(_))));
+
+        // Missing port= prefix
+        let result = ServerConfig::from_string("server=web01,8080");
+        assert!(matches!(result, Err(TemplateError::Parse(_))));
+
+        // Invalid port
+        let result = ServerConfig::from_string("server=web01,port=abc");
+        assert!(matches!(result, Err(TemplateError::Parse(_))));
+    }
+
+    /// Generic KeyValue implementation from docs
+    struct KeyValue<T> {
+        key: String,
+        value: T,
+    }
+
+    impl<T> Template for KeyValue<T>
+    where
+        T: std::fmt::Display + std::str::FromStr + Clone,
+        T::Err: std::fmt::Display,
+    {
+        type Error = TemplateError;
+        type Struct = KeyValue<T>;
+
+        fn to_string(&self) -> String {
+            format!("{}={}", self.key, self.value)
+        }
+
+        fn from_string(s: &str) -> Result<Self::Struct, Self::Error> {
+            let parts: Vec<&str> = s.splitn(2, '=').collect();
+            if parts.len() != 2 {
+                return Err(TemplateError::Parse("Expected key=value format".to_string()));
+            }
+
+            let key = parts[0].to_string();
+            let value = parts[1].parse::<T>()
+                .map_err(|e| TemplateError::Parse(format!("Failed to parse value: {}", e)))?;
+
+            Ok(KeyValue { key, value })
+        }
+    }
+
+    #[test]
+    fn generic_key_value_string() {
+        let config = KeyValue { key: "name".to_string(), value: "test".to_string() };
+        assert_eq!(config.to_string(), "name=test");
+
+        let parsed = KeyValue::<String>::from_string("title=hello world").unwrap();
+        assert_eq!(parsed.key, "title");
+        assert_eq!(parsed.value, "hello world");
+    }
+
+    #[test]
+    fn generic_key_value_numeric() {
+        let config = KeyValue { key: "timeout".to_string(), value: 30u32 };
+        assert_eq!(config.to_string(), "timeout=30");
+
+        let parsed = KeyValue::<u32>::from_string("retry=5").unwrap();
+        assert_eq!(parsed.key, "retry");
+        assert_eq!(parsed.value, 5);
+    }
+
+    #[test]
+    fn generic_key_value_boolean() {
+        let config = KeyValue { key: "enabled".to_string(), value: true };
+        assert_eq!(config.to_string(), "enabled=true");
+
+        let parsed = KeyValue::<bool>::from_string("debug=false").unwrap();
+        assert_eq!(parsed.key, "debug");
+        assert_eq!(parsed.value, false);
+    }
+
+    #[test]
+    fn generic_key_value_parse_errors() {
+        // No equals sign
+        let result = KeyValue::<u32>::from_string("timeout30");
+        assert!(matches!(result, Err(TemplateError::Parse(_))));
+
+        // Invalid numeric value
+        let result = KeyValue::<u32>::from_string("timeout=abc");
+        assert!(matches!(result, Err(TemplateError::Parse(_))));
+    }
+
+    /// Custom error type implementation
+    #[derive(Debug)]
+    struct CustomError(String);
+
+    impl std::fmt::Display for CustomError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "Custom error: {}", self.0)
+        }
+    }
+
+    impl std::error::Error for CustomError {}
+
+    #[derive(Debug)]
+    struct CustomConfig {
+        value: String,
+    }
+
+    impl Template for CustomConfig {
+        type Error = CustomError;
+        type Struct = CustomConfig;
+
+        fn to_string(&self) -> String {
+            format!("custom:{}", self.value)
+        }
+
+        fn from_string(s: &str) -> Result<Self::Struct, Self::Error> {
+            if let Some(value) = s.strip_prefix("custom:") {
+                Ok(CustomConfig { value: value.to_string() })
+            } else {
+                Err(CustomError("Missing custom: prefix".to_string()))
+            }
+        }
+    }
+
+    #[test]
+    fn custom_error_type() {
+        let config = CustomConfig { value: "test".to_string() };
+        assert_eq!(config.to_string(), "custom:test");
+
+        let parsed = CustomConfig::from_string("custom:hello").unwrap();
+        assert_eq!(parsed.value, "hello");
+
+        let result = CustomConfig::from_string("invalid");
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().to_string(), "Custom error: Missing custom: prefix");
+    }
+}
+
+/// Tests for edge cases in manual implementations
+mod manual_implementation_edge_cases {
+    use super::*;
+
+    /// Unit struct implementation
+    struct Unit;
+
+    impl Template for Unit {
+        type Error = TemplateError;
+        type Struct = Unit;
+
+        fn to_string(&self) -> String {
+            "unit".to_string()
+        }
+
+        fn from_string(s: &str) -> Result<Self::Struct, Self::Error> {
+            if s == "unit" {
+                Ok(Unit)
+            } else {
+                Err(TemplateError::Parse("Expected 'unit'".to_string()))
+            }
+        }
+    }
+
+    #[test]
+    fn unit_struct_implementation() {
+        let unit = Unit;
+        assert_eq!(unit.to_string(), "unit");
+
+        let parsed = Unit::from_string("unit").unwrap();
+        let _ = parsed; // Unit has no fields to check
+
+        let result = Unit::from_string("invalid");
+        assert!(matches!(result, Err(TemplateError::Parse(_))));
+    }
+
+    /// Empty template implementation
+    struct Empty {
+        _phantom: std::marker::PhantomData<()>,
+    }
+
+    impl Template for Empty {
+        type Error = TemplateError;
+        type Struct = Empty;
+
+        fn to_string(&self) -> String {
+            "".to_string()
+        }
+
+        fn from_string(s: &str) -> Result<Self::Struct, Self::Error> {
+            if s.is_empty() {
+                Ok(Empty { _phantom: std::marker::PhantomData })
+            } else {
+                Err(TemplateError::Parse("Expected empty string".to_string()))
+            }
+        }
+    }
+
+    #[test]
+    fn empty_template_implementation() {
+        let empty = Empty { _phantom: std::marker::PhantomData };
+        assert_eq!(empty.to_string(), "");
+
+        let parsed = Empty::from_string("").unwrap();
+        let _ = parsed; // No fields to check
+
+        let result = Empty::from_string("not empty");
+        assert!(matches!(result, Err(TemplateError::Parse(_))));
+    }
+
+    /// Complex nested structure
+    struct ComplexNested {
+        outer: String,
+        inner: Vec<String>,
+    }
+
+    impl Template for ComplexNested {
+        type Error = TemplateError;
+        type Struct = ComplexNested;
+
+        fn to_string(&self) -> String {
+            format!("{}:[{}]", self.outer, self.inner.join(","))
+        }
+
+        fn from_string(s: &str) -> Result<Self::Struct, Self::Error> {
+            if let Some((outer_part, inner_part)) = s.split_once(':') {
+                if let (Some(inner_content), true) = (inner_part.strip_prefix('[').and_then(|s| s.strip_suffix(']')), inner_part.starts_with('[') && inner_part.ends_with(']')) {
+                    let inner = if inner_content.is_empty() {
+                        Vec::new()
+                    } else {
+                        inner_content.split(',').map(|s| s.to_string()).collect()
+                    };
+                    
+                    Ok(ComplexNested {
+                        outer: outer_part.to_string(),
+                        inner,
+                    })
+                } else {
+                    Err(TemplateError::Parse("Invalid inner format, expected [...]".to_string()))
+                }
+            } else {
+                Err(TemplateError::Parse("Expected outer:inner format".to_string()))
+            }
+        }
+    }
+
+    #[test]
+    fn complex_nested_implementation() {
+        let complex = ComplexNested {
+            outer: "test".to_string(),
+            inner: vec!["a".to_string(), "b".to_string(), "c".to_string()],
+        };
+        
+        assert_eq!(complex.to_string(), "test:[a,b,c]");
+
+        let parsed = ComplexNested::from_string("hello:[x,y,z]").unwrap();
+        assert_eq!(parsed.outer, "hello");
+        assert_eq!(parsed.inner, vec!["x", "y", "z"]);
+
+        // Empty inner
+        let empty_inner = ComplexNested::from_string("empty:[]").unwrap();
+        assert_eq!(empty_inner.outer, "empty");
+        assert!(empty_inner.inner.is_empty());
+    }
+
+    #[test]
+    fn complex_nested_parse_errors() {
+        // Missing colon
+        let result = ComplexNested::from_string("no_colon");
+        assert!(matches!(result, Err(TemplateError::Parse(_))));
+
+        // Missing brackets
+        let result = ComplexNested::from_string("test:no_brackets");
+        assert!(matches!(result, Err(TemplateError::Parse(_))));
+
+        // Mismatched brackets
+        let result = ComplexNested::from_string("test:[missing_close");
+        assert!(matches!(result, Err(TemplateError::Parse(_))));
+    }
+}


### PR DESCRIPTION
- Introduce extensive unit tests for `Template` trait and custom implementations
- Add `validate_template_safety` to prevent ambiguous placeholders in templates
- Enhance parsing with placeholder conflict detection and stricter rules
- Update `templatia-derive` with support for consecutive placeholder constraints
- Expand `templatia-derive` architecture with `utils` and `validator` modules
- Bump version to `0.0.2` across `templatia` and `templatia-derive` packages
- Refactor parser to handle escaped braces and rounding edge cases