### PR TITLE
Update README and README-ja, and fix mistaken compile error message

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -62,7 +62,7 @@ fn main() {
 テンプレートを指定しない場合、各フィールドが1行ずつ `field_name = {field_name}` という形式で合成されます。
 例えば
 ```rust
-#[derive(Templatia)]
+#[derive(Template)]
 struct AwesomeStruct {
   data1: String,
   data2: u32,

--- a/README-ja.md
+++ b/README-ja.md
@@ -126,7 +126,7 @@ templatia は解析や検証に関するシンプルなエラー型を提供し�
 - templatia
   - Template トレイト
     - `templatia`の振る舞いを定義したトレイトです。  
-      `to_string()`と`from_string()`という二つのメソッドと`type::Error`を定義しています。
+      `to_string()`と`from_string()`という二つのメソッドと関連型の`Error`を定義しています。
   - TemplateError
     - templatia-deriveのデフォルトのエラーです。
 - templatia-derive
@@ -141,7 +141,7 @@ templatia は解析や検証に関するシンプルなエラー型を提供し�
 - 0.0.2
   - [x] 欠損データのデフォルト挙動を定義: `#[templatia(allow_missing_placeholders)]` 属性により、テンプレートに含まれないフィールドを `Default::default()` で初期化可能
   - [ ] Option<T>: プレースホルダが無い場合は既定で None（`allow_missing_placeholders` 不要で自動対応）
-  - [ ] Template構造体から`type::Struct`を削除
+  - [ ] `Template`構造体から関連型の`type Struct`を削除
 - 0.0.3
   - [ ] エラーハンドリングと警告の充実化（診断の明確化とカバレッジ拡大）
 - 0.0.4

--- a/README-ja.md
+++ b/README-ja.md
@@ -18,7 +18,7 @@ Rustの構造体とテキストのシームレスな相互変換をユーザが�
     - 隣り合うことで曖昧さを生む組み合わせの接触コンパイルエラー
       - StructName: Placeholder "field1" and "field2" are consecutive. These are ambiguous to parsing.
         "field1" is `String` type data. Consecutive allows only: [char, bool]
-    - 構造体フィールド全てがテンプレート内のプレースホルダーに含まれない場合のコンパルエラー
+    - 構造体フィールド全てがテンプレート内のプレースホルダーに含まれない場合のコンパイルエラー
       - StructName has more field specified than the template's placeholders: field1, field2, field3
         If you want to allow missing placeholders, use `#[templatia(allow_missing_placeholders)]` attribute.
 
@@ -112,7 +112,7 @@ fn main() {
 - テンプレートで使用されるフィールド型は Display と FromStr を実装している必要があります
   - `allow_missing_placeholders`を有効にしている場合にはDefaultの実装も必要になります。
 - 同じフィールドのプレースホルダーを複数回テンプレート内で利用することが可能ですが、from_string()時には同じフィールドのプレースホルダーは同じ値である必要があります。
-  - `"{first_name} (Full: {first_name} {familiy_name})"`となっていた場合に`Taro (Full: Jiro Yamada)`を構造体にデシリアライズすることはできません。
+  - `"{first_name} (Full: {first_name} {family_name})"`となっていた場合に`Taro (Full: Jiro Yamada)`を構造体にデシリアライズすることはできません。
 
 ## 実行時エラー
 templatia は解析や検証に関するシンプルなエラー型を提供します。

--- a/README-ja.md
+++ b/README-ja.md
@@ -1,30 +1,43 @@
 # templatia
 
-構造体をシンプルなテキストテンプレートへ変換し、文字列から再構築するためのRustライブラリです。構成は以下の2クレートです。
+Rustの構造体とテキストのシームレスな相互変換をユーザが定義するテンプレートに従って実現するテンプレートベースのシリアライズ/デシリアライズライブラリです。
+このライブラリは以下の二つのクレートから実現しています。
 
-- templatia: コアのトレイトとエラー型
-- templatia-derive: 構造体用の実装を自動生成するプロシージャルマクロ
+- templatia: コアのトレイトとエラーを提供するライブラリ
+- templatia-derive: ユーザのテンプレートに従って構造体とテキストの相互互換を実現するための処理を自動生成するマクロライブラリ
 
-どちらのクレートも本リポジトリに含まれます。多くの利用者は、templatia を derive 機能とともに依存に追加するだけで利用できます。
+通常はどちらかを単体で利用するのではなく、`templatia`の`derive`feature経由で組み合わせて利用することが想定されたライブラリです。
+(ただし、templatia-deriveは現時点では`named_struct`のみをサポートしているため、特殊な型には独自実装することも可能です。)
 
 ## 特徴
-- 名前付き構造体に対する Template の導出
-- デフォルトのテンプレートを自動生成（1フィールド1行: `name = {name}`）
-- 属性でカスタムテンプレートを指定: `#[templatia(template = "...")]`
-- ラウンドトリップ対応: `to_string` と `from_string`
-- 分かりやすいエラー（`TemplateError`）
+- Rustの構造体とテキストのシームレスな相互変換
+- デフォルトテンプレートとして全てのフィールドをkey-value形式: `{field_name} = {field_name}`
+- `templatia`属性を利用したカスタムテンプレートの定義: `#[templatia(template = "...")]`
+- 明確な実行時エラーと分かりやすいコンパイルエラーの出力
+  - コンパイルエラーの例
+    - 隣り合うことで曖昧さを生む組み合わせの接触コンパイルエラー
+      - StructName: Placeholder "field1" and "field2" are consecutive. These are ambiguous to parsing.
+        "field1" is `String` type data. Consecutive allows only: [char, bool]
+    - 構造体フィールド全てがテンプレート内のプレースホルダーに含まれない場合のコンパルエラー
+      - StructName has more field specified than the template's placeholders: field1, field2, field3
+        If you want to allow missing placeholders, use `#[templatia(allow_missing_placeholders)]` attribute.
+
 
 ## 対応Rustバージョン（MSRV）
 - Rust 1.85.0
 - Edition 2024
 
 ## インストール
-Cargo.toml に templatia を追加します。
+### cargo addコマンドを利用する
+```shell
+cargo add templatia --features derive
+```
 
-1) templatiaをインポートする。通常featuresに"derive"を追加して利用することを想定しています。
+### Cargo.tomlで直接記述する
+1) templatiaをインポートする。featuresには`derive`を追加します。
 ```toml
 [dependencies]
-templatia = { version = "0.0.1", features = ["derive"] }
+templatia = { version = "0.0.2", features = ["derive"] }
 ```
 
 ```rust
@@ -44,17 +57,36 @@ fn main() {
 }
 ```
 
-## 使い方
-### デフォルトテンプレート
-テンプレートを指定しない場合、各フィールドが1行ずつ `name = {name}` という形式で合成されます。
+## クイックスタートガイド
+### デフォルトのテンプレート
+テンプレートを指定しない場合、各フィールドが1行ずつ `field_name = {field_name}` という形式で合成されます。
+例えば
+```rust
+#[derive(Templatia)]
+struct AwesomeStruct {
+  data1: String,
+  data2: u32,
+}
 
-```text
-name = {name}
-port = {port}
+fn main() {
+  let data = AwesomeStruct { data1: "data1".into(), data2: 100 };
+}
 ```
+のようにした場合は
+```text
+data1 = {data1}
+data2 = {data2}
+```
+という形式でテンプレートが生成され、to_string()を実行した場合には
+```text
+data1 = data1
+data2 = 100
+```
+という出力を得ることができます。
 
 ### カスタムテンプレート
-構造体のフィールド名のプレースホルダを使い、templatia 属性で書式を指定できます。
+`templatia`属性内の`template`に構造体のフィールド名で`{}`で囲ったプレースホルダーを使用すると、カスタムのテンプレートを定義できます。  
+以下のケースでは`"{host}:{port}"`を定義しているため、`cfg`からは`db.example.com:3306`を得ることができます。
 ```rust
 use templatia::Template;
 
@@ -78,9 +110,11 @@ fn main() {
 ### プレースホルダと型
 - テンプレート内の `{name}` は、該当する名前付きフィールドと一致している必要があります
 - テンプレートで使用されるフィールド型は Display と FromStr を実装している必要があります
-- 同じプレースホルダを複数回登場させることは可能ですが、解析結果は互いに矛盾しない必要があります
+  - `allow_missing_placeholders`を有効にしている場合にはDefaultの実装も必要になります。
+- 同じフィールドのプレースホルダーを複数回テンプレート内で利用することが可能ですが、from_string()時には同じフィールドのプレースホルダーは同じ値である必要があります。
+  - `"{first_name} (Full: {first_name} {familiy_name})"`となっていた場合に`Taro (Full: Jiro Yamada)`を構造体にデシリアライズすることはできません。
 
-## エラー
+## 実行時エラー
 templatia は解析や検証に関するシンプルなエラー型を提供します。
 
 - TemplateError::InconsistentValues { placeholder, first_value, second_value }
@@ -90,21 +124,24 @@ templatia は解析や検証に関するシンプルなエラー型を提供し�
 
 ## クレート概要
 - templatia
-  - Template トレイト（`fn to_string(&self) -> String` と `fn from_string(s: &str) -> Result<Self::Struct, Self::Error>`）
-  - エラー報告のための TemplateError 列挙型
+  - Template トレイト
+    - `templatia`の振る舞いを定義したトレイトです。  
+      `to_string()`と`from_string()`という二つのメソッドと`type::Error`を定義しています。
+  - TemplateError
+    - templatia-deriveのデフォルトのエラーです。
 - templatia-derive
-  - 名前付き構造体用の #[derive(Template)] マクロ
+  - #[derive(Template)] マクロ
   - オプション属性: `#[templatia(template = "...")]`
-  - プレースホルダが実在するフィールドに対応しているか検証
 
 ## フィーチャフラグ
 - derive
-  - 
+  - templatia-deriveを有効にするフラグです。これを有効にすることで`templatia::Template`をderiveできるようになります。
 
 ## Road Map（0.0.x → 0.1.0）
 - 0.0.2
   - [x] 欠損データのデフォルト挙動を定義: `#[templatia(allow_missing_placeholders)]` 属性により、テンプレートに含まれないフィールドを `Default::default()` で初期化可能
   - [ ] Option<T>: プレースホルダが無い場合は既定で None（`allow_missing_placeholders` 不要で自動対応）
+  - [ ] Template構造体から`type::Struct`を削除
 - 0.0.3
   - [ ] エラーハンドリングと警告の充実化（診断の明確化とカバレッジ拡大）
 - 0.0.4
@@ -121,8 +158,8 @@ templatia は解析や検証に関するシンプルなエラー型を提供し�
 
 ## ライセンス
 次のいずれかのライセンスでデュアルライセンスされています:
-- Apache License, Version 2.0 (LICENSE-APACHE または http://www.apache.org/licenses/LICENSE-2.0)
-- MIT ライセンス (LICENSE-MIT または http://opensource.org/licenses/MIT)
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-ap.md) または http://www.apache.org/licenses/LICENSE-2.0)
+- MIT ライセンス ([LICENSE-MIT](LICENSE-mit.md) または http://opensource.org/licenses/MIT)
 
 いずれかの条件に従って本ソフトウェアを利用できます。
 

--- a/README.md
+++ b/README.md
@@ -159,8 +159,8 @@ This repository follows AGENTS.md for documentation and testing conventions. In 
 
 ## License
 Dual-licensed under either of:
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-AP) or http://www.apache.org/licenses/LICENSE-2.0)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-ap.md) or http://www.apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](LICENSE-mit.md) or http://opensource.org/licenses/MIT)
 
 You may use this software under the terms of either license.
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ This repository follows AGENTS.md for documentation and testing conventions. In 
 
 ## License
 Dual-licensed under either of:
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-AP) or http://www.apache.org/licenses/LICENSE-2.0)
 - MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
 
 You may use this software under the terms of either license.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ fn main() {
 When no template is specified, each field is synthesized in the format `field_name = {field_name}`, one per line.
 For example:
 ```rust
-#[derive(Templatia)]
+#[derive(Template)]
 struct AwesomeStruct {
   data1: String,
   data2: u32,

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ templatia defines a simple error type for parsing and validation:
 - templatia
   - Template trait
     - A trait that defines the behavior of `templatia`.
-      It defines two methods: `to_string()` and `from_string()`, and `type::Error`.
+      It defines two methods: `to_string()` and `from_string()`, and related type: `Error`.
   - TemplateError enum for error reporting
 - templatia-derive
   - #[derive(Template)] macro for named structs
@@ -142,7 +142,7 @@ templatia defines a simple error type for parsing and validation:
 - 0.0.2
   - [x] Define default behavior for missing data: `#[templatia(allow_missing_placeholders)]` attribute allows fields not in template to use `Default::default()`
   - [ ] Option<T>: default to `None` when the placeholder is absent (automatic support without requiring `allow_missing_placeholders`)
-  - [ ] Remove `type::Struct` from Template trait
+  - [ ] Remove `type Struct` from `Template` trait
 - 0.0.3
   - [ ] Enrich error handling and warnings (clearer diagnostics and coverage)
 - 0.0.4
@@ -159,8 +159,8 @@ This repository follows AGENTS.md for documentation and testing conventions. In 
 
 ## License
 Dual-licensed under either of:
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-ap.md) or http://www.apache.org/licenses/LICENSE-2.0)
-- MIT license ([LICENSE-MIT](LICENSE-mit.md) or http://opensource.org/licenses/MIT)
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
 
 You may use this software under the terms of either license.
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ fn main() {
 - Field types used in the template must implement Display and FromStr
   - When `allow_missing_placeholders` is enabled, the Default trait implementation is also required.
 - It is possible to use placeholders for the same field multiple times within the template, but during from_string() the placeholders for the same field must have the same value.
-  - For example, if the template is `"{first_name} (Full: {first_name} {familiy_name})"`, you cannot deserialize `Taro (Full: Jiro Yamada)` into the struct.
+  - For example, if the template is `"{first_name} (Full: {first_name} {family_name})"`, you cannot deserialize `Taro (Full: Jiro Yamada)` into the struct.
 
 ## Runtime Errors
 templatia defines a simple error type for parsing and validation:

--- a/README.md
+++ b/README.md
@@ -1,31 +1,43 @@
 # templatia
 
-A library for turning structs into simple text templates and parsing them back. It consists of:
+A template-based serialization/deserialization library that enables seamless bidirectional conversion between Rust structs and text according to user-defined templates.
+This library is realized through two crates:
 
-- templatia: the core trait and error type
-- templatia-derive: a procedural macro that implements the trait for your struct
+- templatia: A library providing core traits and errors
+- templatia-derive: A macro library that automatically generates logic for bidirectional conversion between structs and text according to user templates
 
-Both crates are part of this repository. Most users will depend only on templatia with the derive feature enabled.
+Typically, these are not used individually but combined via the `derive` feature of `templatia`.
+(However, since templatia-derive currently only supports `named_struct`, custom implementations are also possible for special types.)
 
 ## Features
-- Derive Template for named structs
-- Auto-generate a default template (one field per line: `name = {name}`)
-- Optional custom template via attribute: `#[templatia(template = "...")]`
-- Round-trip support: `to_string` and `from_string`
-- Clear error reporting (`TemplateError`)
+- Seamless bidirectional conversion between Rust structs and text
+- Default template with all fields in key-value format: `{field_name} = {field_name}`
+- Custom template definition using `templatia` attribute: `#[templatia(template = "...")]`
+- Clear runtime errors and understandable compile errors
+  - Examples of compile errors
+    - Compile error for consecutive ambiguous combinations
+      - StructName: Placeholder "field1" and "field2" are consecutive. These are ambiguous to parsing.
+        "field1" is `String` type data. Consecutive allows only: [char, bool]
+    - Compile error when not all struct fields are included in template placeholders
+      - StructName has more field specified than the template's placeholders: field1, field2, field3
+        If you want to allow missing placeholders, use `#[templatia(allow_missing_placeholders)]` attribute.
 
 ## Minimum supported Rust version (MSRV)
 - Rust 1.85.0
 - Edition 2024
 
 ## Installation
-Add templatia to your Cargo.toml. You can either:
+### Using the cargo add command
+```shell
+cargo add templatia --features derive
+```
 
-1) Use the derive feature and import everything from templatia
+### Direct specification in Cargo.toml
+1) Import templatia. Add `derive` to features.
 
 ```toml
 [dependencies]
-templatia = { version = "0.0.1", features = ["derive"] }
+templatia = { version = "0.0.2", features = ["derive"] }
 ```
 
 ```rust
@@ -46,17 +58,35 @@ fn main() {
 ```
 
 
-## Usage
+## Quick Start Guide
 ### Default template
-When no template is specified, a default template is synthesized with one field per line:
+When no template is specified, each field is synthesized in the format `field_name = {field_name}`, one per line.
+For example:
+```rust
+#[derive(Templatia)]
+struct AwesomeStruct {
+  data1: String,
+  data2: u32,
+}
 
+fn main() {
+  let data = AwesomeStruct { data1: "data1".into(), data2: 100 };
+}
+```
+In this case, the template is generated in the format:
 ```text
-name = {name}
-port = {port}
+data1 = {data1}
+data2 = {data2}
+```
+When executing to_string(), you get the output:
+```text
+data1 = data1
+data2 = 100
 ```
 
 ### Custom template
-Provide a custom format using the templatia attribute and placeholder names that match your struct fields:
+By using placeholders enclosed in `{}` with struct field names in the `template` within the `templatia` attribute, you can define a custom template.
+In the following case, since `"{host}:{port}"` is defined, you can obtain `db.example.com:3306` from `cfg`.
 
 ```rust
 use templatia::Template;
@@ -81,9 +111,11 @@ fn main() {
 ### Placeholders and types
 - Each `{name}` in the template must correspond to a named struct field
 - Field types used in the template must implement Display and FromStr
-- Duplicate placeholders are allowed, but values must be consistent if they appear more than once
+  - When `allow_missing_placeholders` is enabled, the Default trait implementation is also required.
+- It is possible to use placeholders for the same field multiple times within the template, but during from_string() the placeholders for the same field must have the same value.
+  - For example, if the template is `"{first_name} (Full: {first_name} {familiy_name})"`, you cannot deserialize `Taro (Full: Jiro Yamada)` into the struct.
 
-## Errors
+## Runtime Errors
 templatia defines a simple error type for parsing and validation:
 
 - TemplateError::InconsistentValues { placeholder, first_value, second_value }
@@ -93,7 +125,9 @@ templatia defines a simple error type for parsing and validation:
 
 ## Crates overview
 - templatia
-  - Template trait with two methods: `fn to_string(&self) -> String` and `fn from_string(s: &str) -> Result<Self::Struct, Self::Error>`
+  - Template trait
+    - A trait that defines the behavior of `templatia`.
+      It defines two methods: `to_string()` and `from_string()`, and `type::Error`.
   - TemplateError enum for error reporting
 - templatia-derive
   - #[derive(Template)] macro for named structs
@@ -102,12 +136,13 @@ templatia defines a simple error type for parsing and validation:
 
 ## Feature flags
 - derive
-  - Enables the re-export of the proc-macro and the internal parser dependency needed for parsing from strings
+  - A flag that enables templatia-derive. By enabling this, you can derive `templatia::Template`.
 
 ## Road Map (0.0.x roadmap toward 0.1.0)
 - 0.0.2
   - [x] Define default behavior for missing data: `#[templatia(allow_missing_placeholders)]` attribute allows fields not in template to use `Default::default()`
   - [ ] Option<T>: default to `None` when the placeholder is absent (automatic support without requiring `allow_missing_placeholders`)
+  - [ ] Remove `type::Struct` from Template trait
 - 0.0.3
   - [ ] Enrich error handling and warnings (clearer diagnostics and coverage)
 - 0.0.4
@@ -124,8 +159,8 @@ This repository follows AGENTS.md for documentation and testing conventions. In 
 
 ## License
 Dual-licensed under either of:
-- Apache License, Version 2.0 (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0)
-- MIT license (LICENSE-MIT or http://opensource.org/licenses/MIT)
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-ap.md) or http://www.apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](LICENSE-mit.md) or http://opensource.org/licenses/MIT)
 
 You may use this software under the terms of either license.
 

--- a/ROADMAP_CHANGES.md
+++ b/ROADMAP_CHANGES.md
@@ -20,11 +20,13 @@ The initial v0.0.2 roadmap included four items:
 
 - **String-specific configurable handler**: Removed due to lack of consistency. There is no justification for treating `String` fields differently from other types like `u32`, `bool`, or `char`. All types use `Default::default()` when missing, which provides a uniform and predictable behavior. Additionally, the existing `allow_missing_placeholders` attribute already provides the binary choice (error vs default), making a String-specific option redundant.
 
+**Added Items:**
+- **Remove `type::Struct` from Template trait**: Added to reduce complexity. The trait is implemented for a struct, the type of the struct should be itself.
+
 ### Design Rationale
 
 The revised v0.0.2 roadmap follows these principles:
 
-1. **Simplicity over complexity**: Binary choices (allow missing vs error) are clearer than multi-option configurations
+1. **Simplicity over complexity**: Binary choices (allow missing vs error) are clearer than multi-option configurations. Also, the type::Struct removal reduces complexity.
 2. **Consistency**: Treat all types uniformly; avoid special cases for specific types like `String`
 3. **Declarative intent**: Use attributes to make behavior explicit and self-documenting
-

--- a/templatia-derive/src/validator.rs
+++ b/templatia-derive/src/validator.rs
@@ -19,7 +19,7 @@ pub(crate) fn validate_template_safety(
             if !allowed_consecutive {
                 return Err(
                     format!(
-                        "Placeholder \"{0}\" and \"{1}\" is consecutive. These are ambiguous to parsing.\
+                        "Placeholder \"{0}\" and \"{1}\" are consecutive. These are ambiguous to parsing.\
                         \n\"{0}\" is `{2}` type data. Consecutive allows only: [{3}]",
                         first, second, first_type_name, CONSECUTIVE_PLACEHOLDER_ALLOWED_TYPE.join(", ")
                     )


### PR DESCRIPTION
# docs: update documentation and roadmap for v0.0.2 changes

- Update `ROADMAP_CHANGES.md` to document v0.0.2 revisions and reasons for `type::Struct` removal in `Template` trait
- Refine `README.md` and `README-ja.md` with improved explanations, examples, and updated roadmap alignment
- Correct minor grammar issues in `validator.rs` error message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Rewrote and expanded English and Japanese READMEs: clearer runtime-oriented narrative, quick-start, examples for default and custom templates, clarified placeholder/type rules, runtime error descriptions, installation/MSRV notes, feature-flag and license updates, and normalized section names.

- Roadmap
  - Added item to simplify Template trait by removing struct-specific handling.

- Bug Fixes
  - Fixed grammar in an error message about consecutive placeholders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->