### PR TITLE
Fix the variable name for easy to read and understand

### DIFF
--- a/templatia-derive/src/generator.rs
+++ b/templatia-derive/src/generator.rs
@@ -172,6 +172,10 @@ pub(crate) fn generate_str_parser(
     // Generate the duplicate check code which will be expanded to base_value != dup_value
     // Therefore, the execution time, the compare operation is statically determined.
     // Almost cases, the compare is more efficient than the dynamic compare.
+    // To avoid the duplication placeholder gets different value, at least we need to check all the duplication placeholders.
+    // In case, the duplication placeholders are N, the naive compare operation with if, this operation is O(N).
+    // If we use the dynamic compare operation, we cannot reduce the order from my understanding.
+    // (If you have any idea to reduce the order, please let us know!!)
     let dup_conditions = dup_checks
         .iter()
         .map(|(base, dup, _)| quote! { #dup != #base });

--- a/templatia-derive/src/generator.rs
+++ b/templatia-derive/src/generator.rs
@@ -169,7 +169,10 @@ pub(crate) fn generate_str_parser(
         }
     };
 
-    let dup_conds = dup_checks
+    // Generate the duplicate check code which will be expanded to base_value != dup_value
+    // Therefore, the execution time, the compare operation is statically determined.
+    // Almost cases, the compare is more efficient than the dynamic compare.
+    let dup_conditions = dup_checks
         .iter()
         .map(|(base, dup, _)| quote! { #dup != #base });
     let dup_names = dup_checks.iter().map(|(_, _, name)| quote! { #name });
@@ -180,7 +183,7 @@ pub(crate) fn generate_str_parser(
         #generated_full_parser
             .try_map(|#tuple_pattern, span| {
             #(
-                if #dup_conds {
+                if #dup_conditions {
                     return Err(::templatia::__private::chumsky::error::Rich::custom(
                         span,
                         format!(

--- a/templatia-derive/src/generator.rs
+++ b/templatia-derive/src/generator.rs
@@ -169,13 +169,13 @@ pub(crate) fn generate_str_parser(
         }
     };
 
-    // Generate the duplicate check code which will be expanded to base_value != dup_value
-    // Therefore, the execution time, the compare operation is statically determined.
-    // Almost cases, the compare is more efficient than the dynamic compare.
-    // To avoid the duplication placeholder gets different value, at least we need to check all the duplication placeholders.
-    // In case, the duplication placeholders are N, the naive compare operation with if, this operation is O(N).
-    // If we use the dynamic compare operation, we cannot reduce the order from my understanding.
-    // (If you have any idea to reduce the order, please let us know!!)
+    // Generate duplicate check code that expands to base_value != dup_value.
+    // At execution time, the comparison operation is statically determined. In most cases,
+    // static comparison is more efficient than dynamic comparison.
+    // To ensure duplicate placeholders don't receive different values,
+    // all duplicate placeholders must be checked.
+    // If there are N duplicate placeholders, this comparison approach is O(N).
+    // Using dynamic comparison does not appear to reduce this complexity.
     let dup_conditions = dup_checks
         .iter()
         .map(|(base, dup, _)| quote! { #dup != #base });


### PR DESCRIPTION
refactor(templatia-derive): rename variable for clarity and improve inline documentation

- Renamed `dup_conds` to `dup_conditions` for better readability
- Enhanced inline comments to explain duplicate check logic and efficiency considerations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal naming improved for duplicate-condition handling to enhance code clarity and maintainability.
  * No changes to functionality, behavior, error messages, or user-facing validation; existing user experience preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->