### PR TITLE
Rename Template trait methods name and remove associated type named Struct, and update changelog and readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.2] - 2025-10-02
+### Added
+- Support for Option<T>: When a placeholder is absent in the template, fields of type `Option<T>` automatically default to `None`.
+- New attribute `#[templatia(empty_str_option_not_none)]` to treat empty strings for `Option<String>` as `Some("")` instead of the default `None`.
+- New attribute `#[templatia(allow_missing_placeholders)]` to allow fields not present in the template; such fields are initialized with `Default::default()` (requires `Default` for those field types).
+- Compile-time validation to prevent ambiguous consecutive placeholders (e.g., consecutive `String`-like fields) and clearer diagnostics.
+- Extensive tests: comprehensive round-trip tests, option handling tests, manual implementation examples, and compile-fail cases.
+
+### Changed
+- Documentation updates in README.md and README-ja.md to reflect new attributes, defaults, and examples.
+- Internal derive generator refactoring and utility/validator modules to support new parsing and validation logic.
+
+### Fixed
+- Improved and more consistent placeholder handling around edge cases during parsing.
+- Adjusted compile-fail tests for missing fields to reflect new validation behavior.
+
+### Breaking Changes
+- Template trait API change: removed the associated type `type Struct`; `from_string` now returns `Self` instead of `Self::Struct`.
+  - All manual implementations must update their signatures accordingly.
+  - The derive macro has been updated to generate the new signature.
+- Template method name change: `from_string` -> `from_str` and `to_string` -> `render_string`.
+  - All manual implementations must update their signatures accordingly.`
+  - The derive macro has been updated to generate the new signature.
+
 ## [0.0.1] - 2025-09-29
 - Initial release
 - Publish templatia and templatia-derive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,7 @@ All notable changes to this project will be documented in this file.
   - All manual implementations must update their signatures accordingly.
   - The derive macro has been updated to generate the new signature.
 - Template method name change: `from_string` -> `from_str` and `to_string` -> `render_string`.
-  - All manual implementations must update their signatures accordingly.`
-  - The derive macro has been updated to generate the new signature.
+  - The derive macro has been updated to generate the new method names.
 
 ## [0.0.1] - 2025-09-29
 - Initial release

--- a/README-ja.md
+++ b/README-ja.md
@@ -207,7 +207,7 @@ templatia は解析や検証に関するシンプルなエラー型を提供し�
 - 0.0.2
   - [x] 欠損データのデフォルト挙動を定義: `#[templatia(allow_missing_placeholders)]` 属性により、テンプレートに含まれないフィールドを `Default::default()` で初期化可能
   - [x] Option<T>: プレースホルダが無い場合は既定で None（`allow_missing_placeholders` 不要で自動対応）
-  - [x] `Template`構造体から関連型の`type Struct`を削除
+  - [x] `Template`トレイトから関連型の`type Struct`を削除
 - 0.0.3
   - [ ] エラーハンドリングと警告の充実化（診断の明確化とカバレッジ拡大）
 - 0.0.4

--- a/README-ja.md
+++ b/README-ja.md
@@ -51,7 +51,7 @@ struct Config {
 
 fn main() {
     let cfg = Config { host: "localhost".into(), port: 5432 };
-    let s = cfg.to_string();
+    let s = cfg.render_string();
     assert!(s.contains("host = localhost"));
     assert!(s.contains("port = 5432"));
 }
@@ -77,7 +77,7 @@ fn main() {
 data1 = {data1}
 data2 = {data2}
 ```
-という形式でテンプレートが生成され、to_string()を実行した場合には
+という形式でテンプレートが生成され、render_string()を実行した場合には
 ```text
 data1 = data1
 data2 = 100
@@ -99,9 +99,9 @@ struct DbCfg {
 
 fn main() {
     let cfg = DbCfg { host: "db.example.com".into(), port: 3306 };
-    assert_eq!(cfg.to_string(), "db.example.com:3306");
+    assert_eq!(cfg.render_string(), "db.example.com:3306");
 
-    let parsed = DbCfg::from_string("db.example.com:3306").unwrap();
+    let parsed = DbCfg::from_str("db.example.com:3306").unwrap();
     assert_eq!(parsed.host, "db.example.com");
     assert_eq!(parsed.port, 3306);
 }
@@ -123,7 +123,7 @@ struct ServerConfig {
 }
 
 fn main() {
-    let config = ServerConfig::from_string("host=localhost:8080").unwrap();
+    let config = ServerConfig::from_str("host=localhost:8080").unwrap();
     assert_eq!(config.host, "localhost");
     assert_eq!(config.port, 8080);
     assert_eq!(config.username, None); // テンプレートにないため、Noneになる
@@ -143,7 +143,7 @@ struct OptionalValue {
 }
 
 fn main() {
-    let parsed = OptionalValue::from_string("value=").unwrap();
+    let parsed = OptionalValue::from_str("value=").unwrap();
     assert_eq!(parsed.value, Some("".to_string())); // 空文字列がSome("")になる
 }
 ```
@@ -163,7 +163,7 @@ struct Config {
 }
 
 fn main() {
-    let config = Config::from_string("id=42").unwrap();
+    let config = Config::from_str("id=42").unwrap();
     assert_eq!(config.id, 42);
     assert_eq!(config.name, "");          // Stringのデフォルト値
     assert_eq!(config.optional, None);     // Option<T>はNone
@@ -174,7 +174,7 @@ fn main() {
 - テンプレート内の `{name}` は、該当する名前付きフィールドと一致している必要があります
 - テンプレートで使用されるフィールド型は Display と FromStr を実装している必要があります
   - `allow_missing_placeholders`を有効にしている場合にはDefaultの実装も必要になります。
-- 同じフィールドのプレースホルダーを複数回テンプレート内で利用することが可能ですが、from_string()時には同じフィールドのプレースホルダーは同じ値である必要があります。
+- 同じフィールドのプレースホルダーを複数回テンプレート内で利用することが可能ですが、from_str()時には同じフィールドのプレースホルダーは同じ値である必要があります。
   - `"{first_name} (Full: {first_name} {family_name})"`となっていた場合に`Taro (Full: Jiro Yamada)`を構造体にデシリアライズすることはできません。
 
 ## 実行時エラー
@@ -189,7 +189,7 @@ templatia は解析や検証に関するシンプルなエラー型を提供し�
 - templatia
   - Template トレイト
     - `templatia`の振る舞いを定義したトレイトです。  
-      `to_string()`と`from_string()`という二つのメソッドと一つの関連型`Error`を定義しています。
+      `render_string()`と`from_str()`という二つのメソッドと一つの関連型`Error`を定義しています。
   - TemplateError
     - templatia-deriveのデフォルトのエラーです。
 - templatia-derive

--- a/README-ja.md
+++ b/README-ja.md
@@ -107,6 +107,69 @@ fn main() {
 }
 ```
 
+### Option<T>のサポート
+`Option<T>` 型のフィールドは、プレースホルダがテンプレートに存在しない場合、自動的に `None` になります:
+
+```rust
+use templatia::Template;
+
+#[derive(Template)]
+#[templatia(template = "host={host}:{port}", allow_missing_placeholders)]
+struct ServerConfig {
+    host: String,
+    port: u16,
+    username: Option<String>,
+    password: Option<String>,
+}
+
+fn main() {
+    let config = ServerConfig::from_string("host=localhost:8080").unwrap();
+    assert_eq!(config.host, "localhost");
+    assert_eq!(config.port, 8080);
+    assert_eq!(config.username, None); // テンプレートにないため、Noneになる
+    assert_eq!(config.password, None); // テンプレートにないため、Noneになる
+}
+```
+
+デフォルトでは、`Option<String>` の空文字列は `None` としてパースされます。空文字列を `Some("")` として扱うには、`empty_str_option_not_none` 属性を使用します:
+
+```rust
+use templatia::Template;
+
+#[derive(Template)]
+#[templatia(template = "value={value}", empty_str_option_not_none)]
+struct OptionalValue {
+    value: Option<String>,
+}
+
+fn main() {
+    let parsed = OptionalValue::from_string("value=").unwrap();
+    assert_eq!(parsed.value, Some("".to_string())); // 空文字列がSome("")になる
+}
+```
+
+### プレースホルダの欠損を許可
+`allow_missing_placeholders` 属性を使用すると、テンプレートに含まれないフィールドを許可できます:
+
+```rust
+use templatia::Template;
+
+#[derive(Template)]
+#[templatia(template = "id={id}", allow_missing_placeholders)]
+struct Config {
+    id: u32,
+    name: String,           // テンプレートにないため、Default::default()を使用
+    optional: Option<u32>,  // テンプレートにないため、Noneになる
+}
+
+fn main() {
+    let config = Config::from_string("id=42").unwrap();
+    assert_eq!(config.id, 42);
+    assert_eq!(config.name, "");          // Stringのデフォルト値
+    assert_eq!(config.optional, None);     // Option<T>はNone
+}
+```
+
 ### プレースホルダと型
 - テンプレート内の `{name}` は、該当する名前付きフィールドと一致している必要があります
 - テンプレートで使用されるフィールド型は Display と FromStr を実装している必要があります
@@ -126,12 +189,15 @@ templatia は解析や検証に関するシンプルなエラー型を提供し�
 - templatia
   - Template トレイト
     - `templatia`の振る舞いを定義したトレイトです。  
-      `to_string()`と`from_string()`という二つのメソッドと関連型の`Error`を定義しています。
+      `to_string()`と`from_string()`という二つのメソッドと一つの関連型`Error`を定義しています。
   - TemplateError
     - templatia-deriveのデフォルトのエラーです。
 - templatia-derive
   - #[derive(Template)] マクロ
-  - オプション属性: `#[templatia(template = "...")]`
+  - オプション属性:
+    - `#[templatia(template = "...")]` カスタムテンプレート用
+    - `#[templatia(allow_missing_placeholders)]` テンプレートにないフィールドを許可
+    - `#[templatia(empty_str_option_not_none)]` `Option<String>`の空文字列を`Some("")`として扱う
 
 ## フィーチャフラグ
 - derive
@@ -141,7 +207,7 @@ templatia は解析や検証に関するシンプルなエラー型を提供し�
 - 0.0.2
   - [x] 欠損データのデフォルト挙動を定義: `#[templatia(allow_missing_placeholders)]` 属性により、テンプレートに含まれないフィールドを `Default::default()` で初期化可能
   - [x] Option<T>: プレースホルダが無い場合は既定で None（`allow_missing_placeholders` 不要で自動対応）
-  - [ ] `Template`構造体から関連型の`type Struct`を削除
+  - [x] `Template`構造体から関連型の`type Struct`を削除
 - 0.0.3
   - [ ] エラーハンドリングと警告の充実化（診断の明確化とカバレッジ拡大）
 - 0.0.4

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ struct Config {
 
 fn main() {
     let cfg = Config { host: "localhost".into(), port: 5432 };
-    let s = cfg.to_string();
+    let s = cfg.render_string();
     assert!(s.contains("host = localhost"));
     assert!(s.contains("port = 5432"));
 }
@@ -78,7 +78,7 @@ In this case, the template is generated in the format:
 data1 = {data1}
 data2 = {data2}
 ```
-When executing to_string(), you get the output:
+When executing render_string(), you get the output:
 ```text
 data1 = data1
 data2 = 100
@@ -100,9 +100,9 @@ struct DbCfg {
 
 fn main() {
     let cfg = DbCfg { host: "db.example.com".into(), port: 3306 };
-    assert_eq!(cfg.to_string(), "db.example.com:3306");
+    assert_eq!(cfg.render_string(), "db.example.com:3306");
 
-    let parsed = DbCfg::from_string("db.example.com:3306").unwrap();
+    let parsed = DbCfg::from_str("db.example.com:3306").unwrap();
     assert_eq!(parsed.host, "db.example.com");
     assert_eq!(parsed.port, 3306);
 }
@@ -124,7 +124,7 @@ struct ServerConfig {
 }
 
 fn main() {
-    let config = ServerConfig::from_string("host=localhost:8080").unwrap();
+    let config = ServerConfig::from_str("host=localhost:8080").unwrap();
     assert_eq!(config.host, "localhost");
     assert_eq!(config.port, 8080);
     assert_eq!(config.username, None); // Not in template, defaults to None
@@ -144,7 +144,7 @@ struct OptionalValue {
 }
 
 fn main() {
-    let parsed = OptionalValue::from_string("value=").unwrap();
+    let parsed = OptionalValue::from_str("value=").unwrap();
     assert_eq!(parsed.value, Some("".to_string())); // Empty string becomes Some("")
 }
 ```
@@ -164,7 +164,7 @@ struct Config {
 }
 
 fn main() {
-    let config = Config::from_string("id=42").unwrap();
+    let config = Config::from_str("id=42").unwrap();
     assert_eq!(config.id, 42);
     assert_eq!(config.name, "");          // Default for String
     assert_eq!(config.optional, None);     // None for Option<T>
@@ -175,7 +175,7 @@ fn main() {
 - Each `{name}` in the template must correspond to a named struct field
 - Field types used in the template must implement Display and FromStr
   - When `allow_missing_placeholders` is enabled, the Default trait implementation is also required.
-- It is possible to use placeholders for the same field multiple times within the template, but during from_string() the placeholders for the same field must have the same value.
+- It is possible to use placeholders for the same field multiple times within the template, but during from_str() the placeholders for the same field must have the same value.
   - For example, if the template is `"{first_name} (Full: {first_name} {family_name})"`, you cannot deserialize `Taro (Full: Jiro Yamada)` into the struct.
 
 ## Runtime Errors
@@ -190,7 +190,7 @@ templatia defines a simple error type for parsing and validation:
 - templatia
   - Template trait
     - A trait that defines the behavior of `templatia`.
-      It defines two methods: `to_string()` and `from_string()`, and one associated type: `Error`.
+      It defines two methods: `render_string()` and `from_str()`, and one associated type: `Error`.
   - TemplateError enum for error reporting
 - templatia-derive
   - #[derive(Template)] macro for named structs

--- a/templatia-derive/src/lib.rs
+++ b/templatia-derive/src/lib.rs
@@ -234,13 +234,12 @@ pub fn template_derive(input: TokenStream) -> TokenStream {
     quote! {
         impl #impl_generics ::templatia::Template for #name #ty_generics #where_clause {
             type Error = templatia::TemplateError;
-            type Struct = #name #ty_generics;
 
-            fn to_string(&self) -> String {
+            fn render_string(&self) -> String {
                 format!(#format_string, #(#format_args),*)
             }
 
-            fn from_string(s: &str) -> Result<Self::Struct, Self::Error> {
+            fn from_str(s: &str) -> Result<Self, Self::Error> {
                 use ::templatia::__private::chumsky::Parser;
 
                 let parser = #str_from_parser;

--- a/templatia-derive/src/lib.rs
+++ b/templatia-derive/src/lib.rs
@@ -64,8 +64,8 @@ struct TemplateOpts {
 /// # Type Requirements
 ///
 /// All fields referenced in the template must implement:
-/// - `std::fmt::Display` for serialization (`to_string`)
-/// - `std::str::FromStr` for deserialization (`from_string`)
+/// - `std::fmt::Display` for serialization (`render_string`)
+/// - `std::str::FromStr` for deserialization (`from_str`)
 /// - `std::cmp::PartialEq` for consistency validation with duplicate placeholders
 ///
 /// # Compilation Errors

--- a/templatia-derive/tests/comprehensive_tests.rs
+++ b/templatia-derive/tests/comprehensive_tests.rs
@@ -15,10 +15,10 @@ mod default_template_tests {
         let single = SingleField {
             name: "test".into(),
         };
-        let template = single.to_string();
+        let template = single.render_string();
         assert_eq!(template, "name = test");
 
-        let parsed = SingleField::from_string(&template).unwrap();
+        let parsed = SingleField::from_str(&template).unwrap();
         assert_eq!(parsed, single);
     }
 
@@ -36,10 +36,10 @@ mod default_template_tests {
             beta: 42,
             gamma: true,
         };
-        let template = multi.to_string();
+        let template = multi.render_string();
         assert_eq!(template, "alpha = first\nbeta = 42\ngamma = true");
 
-        let parsed = MultiField::from_string(&template).unwrap();
+        let parsed = MultiField::from_str(&template).unwrap();
         assert_eq!(parsed, multi);
     }
 
@@ -66,8 +66,8 @@ mod default_template_tests {
             double_val: std::f64::consts::E,
         };
 
-        let template = nums.to_string();
-        let parsed = NumericTypes::from_string(&template).unwrap();
+        let template = nums.render_string();
+        let parsed = NumericTypes::from_str(&template).unwrap();
         assert_eq!(parsed, nums);
     }
 
@@ -84,10 +84,10 @@ mod default_template_tests {
             flag_false: false,
         };
 
-        let template = bools.to_string();
+        let template = bools.render_string();
         assert_eq!(template, "flag_true = true\nflag_false = false");
 
-        let parsed = BoolValues::from_string(&template).unwrap();
+        let parsed = BoolValues::from_str(&template).unwrap();
         assert_eq!(parsed, bools);
     }
 
@@ -104,10 +104,10 @@ mod default_template_tests {
             normal: "content".into(),
         };
 
-        let template = empty_str.to_string();
+        let template = empty_str.render_string();
         assert_eq!(template, "empty = \nnormal = content");
 
-        let parsed = EmptyString::from_string(&template).unwrap();
+        let parsed = EmptyString::from_str(&template).unwrap();
         assert_eq!(parsed, empty_str);
     }
 }
@@ -132,10 +132,10 @@ mod custom_template_tests {
             database: "production".into(),
         };
 
-        let template = config.to_string();
+        let template = config.render_string();
         assert_eq!(template, "Server: db.example.com | Port: 5432 | DB: production");
 
-        let parsed = ComplexFormat::from_string(&template).unwrap();
+        let parsed = ComplexFormat::from_str(&template).unwrap();
         assert_eq!(parsed, config);
     }
 
@@ -157,10 +157,10 @@ mod custom_template_tests {
             token: "abc123".into(),
         };
 
-        let template = url.to_string();
+        let template = url.render_string();
         assert_eq!(template, "https://api.example.com:443/v1/data?token=abc123");
 
-        let parsed = UrlFormat::from_string(&template).unwrap();
+        let parsed = UrlFormat::from_str(&template).unwrap();
         assert_eq!(parsed, url);
     }
 
@@ -180,10 +180,10 @@ mod custom_template_tests {
             active: true,
         };
 
-        let template = person.to_string();
+        let template = person.render_string();
         assert_eq!(template, r#"{"name": "Alice", "age": 30, "active": true}"#);
 
-        let parsed = JsonLike::from_string(&template).unwrap();
+        let parsed = JsonLike::from_str(&template).unwrap();
         assert_eq!(parsed, person);
     }
 
@@ -203,8 +203,8 @@ mod custom_template_tests {
             notes: "Test notes with symbols: @#$%^&*()".into(),
         };
 
-        let template = user.to_string();
-        let parsed = SpecialChars::from_string(&template).unwrap();
+        let template = user.render_string();
+        let parsed = SpecialChars::from_str(&template).unwrap();
         assert_eq!(parsed, user);
     }
 
@@ -220,10 +220,10 @@ mod custom_template_tests {
             value: "just_this".into(),
         };
 
-        let template = minimal.to_string();
+        let template = minimal.render_string();
         assert_eq!(template, "just_this");
 
-        let parsed = Minimal::from_string(&template).unwrap();
+        let parsed = Minimal::from_str(&template).unwrap();
         assert_eq!(parsed, minimal);
     }
 }
@@ -244,10 +244,10 @@ mod duplicate_placeholder_tests {
             name: "Alice".into(),
         };
 
-        let template = greeting.to_string();
+        let template = greeting.render_string();
         assert_eq!(template, "Hello Alice! Welcome back, Alice!");
 
-        let parsed = Greeting::from_string(&template).unwrap();
+        let parsed = Greeting::from_str(&template).unwrap();
         assert_eq!(parsed, greeting);
     }
 
@@ -261,10 +261,10 @@ mod duplicate_placeholder_tests {
 
         let multi = MultiId { id: 12345 };
 
-        let template = multi.to_string();
+        let template = multi.render_string();
         assert_eq!(template, "12345-12345-12345-12345");
 
-        let parsed = MultiId::from_string(&template).unwrap();
+        let parsed = MultiId::from_str(&template).unwrap();
         assert_eq!(parsed, multi);
     }
 
@@ -276,7 +276,7 @@ mod duplicate_placeholder_tests {
             name: String,
         }
 
-        let result = Inconsistent::from_string("first=alice, second=bob");
+        let result = Inconsistent::from_str("first=alice, second=bob");
         
         match result {
             Err(TemplateError::InconsistentValues {
@@ -300,7 +300,7 @@ mod duplicate_placeholder_tests {
             port: u16,
         }
 
-        let result = NumericInconsistent::from_string("port1=8080 port2=9090");
+        let result = NumericInconsistent::from_str("port1=8080 port2=9090");
         
         match result {
             Err(TemplateError::InconsistentValues {
@@ -332,10 +332,10 @@ mod duplicate_placeholder_tests {
             version: "v1.0".into(),
         };
 
-        let template = mixed.to_string();
+        let template = mixed.render_string();
         assert_eq!(template, "prod-api-prod-v1.0");
 
-        let parsed = MixedDuplicates::from_string(&template).unwrap();
+        let parsed = MixedDuplicates::from_str(&template).unwrap();
         assert_eq!(parsed, mixed);
     }
 }
@@ -352,7 +352,7 @@ mod error_handling_tests {
             port: u16,
         }
 
-        let result = PortConfig::from_string("port=not_a_number");
+        let result = PortConfig::from_str("port=not_a_number");
         
         match result {
             Err(TemplateError::Parse(msg)) => {
@@ -370,7 +370,7 @@ mod error_handling_tests {
             enabled: bool,
         }
 
-        let result = BoolConfig::from_string("enabled=maybe");
+        let result = BoolConfig::from_str("enabled=maybe");
         
         match result {
             Err(TemplateError::Parse(msg)) => {
@@ -388,7 +388,7 @@ mod error_handling_tests {
             value: u8,
         }
 
-        let result = OverflowTest::from_string("value=256");
+        let result = OverflowTest::from_str("value=256");
         
         match result {
             Err(TemplateError::Parse(_)) => {
@@ -406,7 +406,7 @@ mod error_handling_tests {
             count: u32,
         }
 
-        let result = UnsignedTest::from_string("count=-1");
+        let result = UnsignedTest::from_str("count=-1");
         
         match result {
             Err(TemplateError::Parse(_)) => {
@@ -426,7 +426,7 @@ mod error_handling_tests {
         }
 
         // Missing colon separator
-        let result = HostPort::from_string("host=localhost 8080");
+        let result = HostPort::from_str("host=localhost 8080");
         
         match result {
             Err(TemplateError::Parse(_)) => {
@@ -445,7 +445,7 @@ mod error_handling_tests {
         }
 
         // Missing suffix
-        let result = PrefixSuffix::from_string("prefix_test");
+        let result = PrefixSuffix::from_str("prefix_test");
         
         match result {
             Err(TemplateError::Parse(_)) => {
@@ -469,8 +469,8 @@ mod type_constraint_tests {
         }
 
         let original = FloatTest { value: std::f64::consts::PI };
-        let template = original.to_string();
-        let parsed = FloatTest::from_string(&template).unwrap();
+        let template = original.render_string();
+        let parsed = FloatTest::from_str(&template).unwrap();
         
         // Allow for floating point precision differences
         assert!((parsed.value - original.value).abs() < 1e-10);
@@ -490,8 +490,8 @@ mod type_constraint_tests {
             min_val: i64::MIN,
         };
 
-        let template = extreme.to_string();
-        let parsed = ExtremeValues::from_string(&template).unwrap();
+        let template = extreme.render_string();
+        let parsed = ExtremeValues::from_str(&template).unwrap();
         assert_eq!(parsed, extreme);
     }
 
@@ -509,8 +509,8 @@ mod type_constraint_tests {
             float_zero: 0.0,
         };
 
-        let template = zeros.to_string();
-        let parsed = ZeroValues::from_string(&template).unwrap();
+        let template = zeros.render_string();
+        let parsed = ZeroValues::from_str(&template).unwrap();
         assert_eq!(parsed, zeros);
     }
 
@@ -526,8 +526,8 @@ mod type_constraint_tests {
             name: "  spaced  name  ".into(),
         };
 
-        let template = whitespace.to_string();
-        let parsed = WhitespaceTest::from_string(&template).unwrap();
+        let template = whitespace.render_string();
+        let parsed = WhitespaceTest::from_str(&template).unwrap();
         assert_eq!(parsed, whitespace);
     }
 
@@ -543,8 +543,8 @@ mod type_constraint_tests {
             content: "line1\nline2\nline3".into(),
         };
 
-        let template = multiline.to_string();
-        let parsed = NewlineTest::from_string(&template).unwrap();
+        let template = multiline.render_string();
+        let parsed = NewlineTest::from_str(&template).unwrap();
         assert_eq!(parsed, multiline);
     }
 }
@@ -574,8 +574,8 @@ mod field_combination_tests {
             field_f: "omega".into(),
         };
 
-        let template = many.to_string();
-        let parsed = ManyFields::from_string(&template).unwrap();
+        let template = many.render_string();
+        let parsed = ManyFields::from_str(&template).unwrap();
         assert_eq!(parsed, many);
     }
 
@@ -595,10 +595,10 @@ mod field_combination_tests {
             c: false,
         };
 
-        let template = mixed.to_string();
+        let template = mixed.render_string();
         assert_eq!(template, "false-middle-999");
 
-        let parsed = MixedOrder::from_string(&template).unwrap();
+        let parsed = MixedOrder::from_str(&template).unwrap();
         assert_eq!(parsed, mixed);
     }
 
@@ -612,10 +612,10 @@ mod field_combination_tests {
 
         let repeated = RepeatedField { x: 'A' };
 
-        let template = repeated.to_string();
+        let template = repeated.render_string();
         assert_eq!(template, "AAAAAAAA");
 
-        let parsed = RepeatedField::from_string(&template).unwrap();
+        let parsed = RepeatedField::from_str(&template).unwrap();
         assert_eq!(parsed, repeated);
     }
 }
@@ -640,13 +640,13 @@ mod roundtrip_tests {
         };
 
         // First round-trip
-        let template1 = original.to_string();
-        let parsed1 = RoundtripTest::from_string(&template1).unwrap();
+        let template1 = original.render_string();
+        let parsed1 = RoundtripTest::from_str(&template1).unwrap();
         assert_eq!(parsed1, original);
 
         // Second round-trip
-        let template2 = parsed1.to_string();
-        let parsed2 = RoundtripTest::from_string(&template2).unwrap();
+        let template2 = parsed1.render_string();
+        let parsed2 = RoundtripTest::from_str(&template2).unwrap();
         assert_eq!(parsed2, original);
 
         // Templates should be identical
@@ -670,8 +670,8 @@ mod roundtrip_tests {
         // Multiple round-trips
         let mut current = original.clone();
         for _ in 0..5 {
-            let template = current.to_string();
-            current = CustomRoundtrip::from_string(&template).unwrap();
+            let template = current.render_string();
+            current = CustomRoundtrip::from_str(&template).unwrap();
         }
 
         assert_eq!(current, original);
@@ -706,8 +706,8 @@ mod roundtrip_tests {
         ];
 
         for original in edge_cases {
-            let template = original.to_string();
-            let parsed = EdgeCaseRoundtrip::from_string(&template).unwrap();
+            let template = original.render_string();
+            let parsed = EdgeCaseRoundtrip::from_str(&template).unwrap();
             assert_eq!(parsed, original, "Failed roundtrip for: {:?}", original);
         }
     }
@@ -731,10 +731,10 @@ mod consecutive_placeholder_tests {
             second: 'B',
         };
 
-        let template = chars.to_string();
+        let template = chars.render_string();
         assert_eq!(template, "AB");
 
-        let parsed = ConsecutiveChars::from_string(&template).unwrap();
+        let parsed = ConsecutiveChars::from_str(&template).unwrap();
         assert_eq!(parsed, chars);
     }
 
@@ -752,10 +752,10 @@ mod consecutive_placeholder_tests {
             flag2: false,
         };
 
-        let template = bools.to_string();
+        let template = bools.render_string();
         assert_eq!(template, "truefalse");
 
-        let parsed = ConsecutiveBools::from_string(&template).unwrap();
+        let parsed = ConsecutiveBools::from_str(&template).unwrap();
         assert_eq!(parsed, bools);
     }
 
@@ -773,10 +773,10 @@ mod consecutive_placeholder_tests {
             flag: true,
         };
 
-        let template = mixed.to_string();
+        let template = mixed.render_string();
         assert_eq!(template, "Xtrue");
 
-        let parsed = MixedCharBool::from_string(&template).unwrap();
+        let parsed = MixedCharBool::from_str(&template).unwrap();
         assert_eq!(parsed, mixed);
     }
 
@@ -794,10 +794,10 @@ mod consecutive_placeholder_tests {
             grade: 'A',
         };
 
-        let template = bc.to_string();
+        let template = bc.render_string();
         assert_eq!(template, "falseA");
 
-        let parsed = BoolChar::from_string(&template).unwrap();
+        let parsed = BoolChar::from_str(&template).unwrap();
         assert_eq!(parsed, bc);
     }
 
@@ -819,10 +819,10 @@ mod consecutive_placeholder_tests {
             d: 'T',
         };
 
-        let template = multi.to_string();
+        let template = multi.render_string();
         assert_eq!(template, "TEST");
 
-        let parsed = MultipleChars::from_string(&template).unwrap();
+        let parsed = MultipleChars::from_str(&template).unwrap();
         assert_eq!(parsed, multi);
     }
 
@@ -842,10 +842,10 @@ mod consecutive_placeholder_tests {
             c: true,
         };
 
-        let template = multi.to_string();
+        let template = multi.render_string();
         assert_eq!(template, "truefalsetrue");
 
-        let parsed = MultipleBools::from_string(&template).unwrap();
+        let parsed = MultipleBools::from_str(&template).unwrap();
         assert_eq!(parsed, multi);
     }
 
@@ -863,10 +863,10 @@ mod consecutive_placeholder_tests {
             second: 'Z',
         };
 
-        let template = sep.to_string();
+        let template = sep.render_string();
         assert_eq!(template, "A-Z");
 
-        let parsed = SeparatedChars::from_string(&template).unwrap();
+        let parsed = SeparatedChars::from_str(&template).unwrap();
         assert_eq!(parsed, sep);
     }
 
@@ -884,10 +884,10 @@ mod consecutive_placeholder_tests {
             disabled: false,
         };
 
-        let template = sep.to_string();
+        let template = sep.render_string();
         assert_eq!(template, "true|false");
 
-        let parsed = SeparatedBools::from_string(&template).unwrap();
+        let parsed = SeparatedBools::from_str(&template).unwrap();
         assert_eq!(parsed, sep);
     }
 }
@@ -908,10 +908,10 @@ mod escaped_brace_tests {
             value: "test".into(),
         };
 
-        let template = escaped.to_string();
+        let template = escaped.render_string();
         assert_eq!(template, "{value=test");
 
-        let parsed = EscapedOpen::from_string(&template).unwrap();
+        let parsed = EscapedOpen::from_str(&template).unwrap();
         assert_eq!(parsed, escaped);
     }
 
@@ -927,10 +927,10 @@ mod escaped_brace_tests {
             value: "test".into(),
         };
 
-        let template = escaped.to_string();
+        let template = escaped.render_string();
         assert_eq!(template, "value=test}");
 
-        let parsed = EscapedClose::from_string(&template).unwrap();
+        let parsed = EscapedClose::from_str(&template).unwrap();
         assert_eq!(parsed, escaped);
     }
 
@@ -946,10 +946,10 @@ mod escaped_brace_tests {
             value: "test".into(),
         };
 
-        let template = escaped.to_string();
+        let template = escaped.render_string();
         assert_eq!(template, "{data: test}");
 
-        let parsed = BothEscaped::from_string(&template).unwrap();
+        let parsed = BothEscaped::from_str(&template).unwrap();
         assert_eq!(parsed, escaped);
     }
 
@@ -965,10 +965,10 @@ mod escaped_brace_tests {
             value: "data".into(),
         };
 
-        let template = escaped.to_string();
+        let template = escaped.render_string();
         assert_eq!(template, "{{prefix}}: data");
 
-        let parsed = MultipleEscaped::from_string(&template).unwrap();
+        let parsed = MultipleEscaped::from_str(&template).unwrap();
         assert_eq!(parsed, escaped);
     }
 }
@@ -992,12 +992,12 @@ mod missing_field_tests {
             port: 8080,
         };
 
-        // to_string only includes template fields
-        let template = config.to_string();
+        // render_string only includes template fields
+        let template = config.render_string();
         assert_eq!(template, "name=server");
 
-        // from_string sets missing field to default
-        let parsed = PartialConfig::from_string(&template).unwrap();
+        // from_str sets missing field to default
+        let parsed = PartialConfig::from_str(&template).unwrap();
         assert_eq!(parsed.name, "server");
         assert_eq!(parsed.port, 0); // Default for u16
     }
@@ -1020,10 +1020,10 @@ mod missing_field_tests {
             count: -5,
         };
 
-        let template = instance.to_string();
+        let template = instance.render_string();
         assert_eq!(template, "id=42");
 
-        let parsed = MultiMissing::from_string(&template).unwrap();
+        let parsed = MultiMissing::from_str(&template).unwrap();
         assert_eq!(parsed.id, 42);
         assert_eq!(parsed.name, ""); // Default for String
         assert_eq!(parsed.enabled, false); // Default for bool
@@ -1048,10 +1048,10 @@ mod missing_field_tests {
             port: 443,
         };
 
-        let template = creds.to_string();
+        let template = creds.render_string();
         assert_eq!(template, "user=admin:pass=secret");
 
-        let parsed = Credentials::from_string(&template).unwrap();
+        let parsed = Credentials::from_str(&template).unwrap();
         assert_eq!(parsed.user, "admin");
         assert_eq!(parsed.pass, "secret");
         assert_eq!(parsed.domain, ""); // Default
@@ -1080,10 +1080,10 @@ mod missing_field_tests {
             character: 'X',
         };
 
-        let template = instance.to_string();
+        let template = instance.render_string();
         assert_eq!(template, "active=true");
 
-        let parsed = AllTypes::from_string(&template).unwrap();
+        let parsed = AllTypes::from_str(&template).unwrap();
         assert_eq!(parsed.active, true);
         assert_eq!(parsed.text, "");
         assert_eq!(parsed.number, 0);
@@ -1109,8 +1109,8 @@ mod missing_field_tests {
             level: 5,
         };
 
-        let template1 = original.to_string();
-        let parsed1 = StatusReport::from_string(&template1).unwrap();
+        let template1 = original.render_string();
+        let parsed1 = StatusReport::from_str(&template1).unwrap();
         
         // Missing fields get defaults
         assert_eq!(parsed1.status, "ok");
@@ -1118,10 +1118,10 @@ mod missing_field_tests {
         assert_eq!(parsed1.level, 0);
 
         // Second roundtrip - template stays the same
-        let template2 = parsed1.to_string();
+        let template2 = parsed1.render_string();
         assert_eq!(template1, template2);
         
-        let parsed2 = StatusReport::from_string(&template2).unwrap();
+        let parsed2 = StatusReport::from_str(&template2).unwrap();
         assert_eq!(parsed2, parsed1);
     }
 
@@ -1139,10 +1139,10 @@ mod missing_field_tests {
             extra: "not_in_template".into(),
         };
 
-        let template = instance.to_string();
+        let template = instance.render_string();
         assert_eq!(template, "A-A-A");
 
-        let parsed = DuplicateWithMissing::from_string(&template).unwrap();
+        let parsed = DuplicateWithMissing::from_str(&template).unwrap();
         assert_eq!(parsed.id, 'A');
         assert_eq!(parsed.extra, ""); // Default
     }
@@ -1161,10 +1161,10 @@ mod missing_field_tests {
             field2: 100,
         };
 
-        let template = instance.to_string();
+        let template = instance.render_string();
         assert_eq!(template, "constant_text");
 
-        let parsed = NoPlaceholders::from_string(&template).unwrap();
+        let parsed = NoPlaceholders::from_str(&template).unwrap();
         assert_eq!(parsed.field1, "");
         assert_eq!(parsed.field2, 0);
     }
@@ -1189,10 +1189,10 @@ mod missing_field_tests {
             address: "123 Main St".into(),
         };
 
-        let template = person.to_string();
+        let template = person.render_string();
         assert_eq!(template, "Name: Alice, Age: 30");
 
-        let parsed = Person::from_string(&template).unwrap();
+        let parsed = Person::from_str(&template).unwrap();
         assert_eq!(parsed.name, "Alice");
         assert_eq!(parsed.age, 30);
         assert_eq!(parsed.email, "");
@@ -1218,10 +1218,10 @@ mod missing_field_tests {
             extra2: 999,
         };
 
-        let template = instance.to_string();
+        let template = instance.render_string();
         assert_eq!(template, "trueX");
 
-        let parsed = ConsecutiveWithMissing::from_string(&template).unwrap();
+        let parsed = ConsecutiveWithMissing::from_str(&template).unwrap();
         assert_eq!(parsed.flag, true);
         assert_eq!(parsed.ch, 'X');
         assert_eq!(parsed.extra1, "");
@@ -1244,10 +1244,10 @@ mod missing_field_tests {
             third: "three".into(),
         };
 
-        let template = instance.to_string();
+        let template = instance.render_string();
         assert_eq!(template, "one");
 
-        let parsed = FirstOnly::from_string(&template).unwrap();
+        let parsed = FirstOnly::from_str(&template).unwrap();
         assert_eq!(parsed.first, "one");
         assert_eq!(parsed.second, "");
         assert_eq!(parsed.third, "");
@@ -1269,10 +1269,10 @@ mod missing_field_tests {
             last: "final".into(),
         };
 
-        let template = instance.to_string();
+        let template = instance.render_string();
         assert_eq!(template, "result=final");
 
-        let parsed = LastOnly::from_string(&template).unwrap();
+        let parsed = LastOnly::from_str(&template).unwrap();
         assert_eq!(parsed.first, 0);
         assert_eq!(parsed.second, false);
         assert_eq!(parsed.last, "final");
@@ -1296,10 +1296,10 @@ mod missing_field_tests {
             d: "D".into(),
         };
 
-        let template = instance.to_string();
+        let template = instance.render_string();
         assert_eq!(template, "A:C");
 
-        let parsed = Alternating::from_string(&template).unwrap();
+        let parsed = Alternating::from_str(&template).unwrap();
         assert_eq!(parsed.a, "A");
         assert_eq!(parsed.b, ""); // Missing
         assert_eq!(parsed.c, "C");

--- a/templatia-derive/tests/derive_basic.rs
+++ b/templatia-derive/tests/derive_basic.rs
@@ -13,7 +13,7 @@ fn default_template_to_string_contains_fields() {
         host: "localhost".into(),
         port: 5432,
     };
-    let s = cfg.to_string();
+    let s = cfg.render_string();
     assert_eq!(s, "host = localhost\nport = 5432");
 }
 
@@ -30,10 +30,10 @@ fn custom_template_roundtrip() {
         host: "example.com".into(),
         port: 8080,
     };
-    let s = url.to_string();
+    let s = url.render_string();
     assert_eq!(s, "url=example.com:8080");
 
-    let parsed = Url::from_string(&s).expect("should parse");
+    let parsed = Url::from_str(&s).expect("should parse");
     assert_eq!(parsed, url);
 }
 
@@ -47,7 +47,7 @@ fn parse_error_is_reported_as_template_error_parse() {
     }
 
     let bad = "host=local\nport=not_a_number";
-    let err = Cfg::from_string(bad).expect_err("expected parse error");
+    let err = Cfg::from_str(bad).expect_err("expected parse error");
     match err {
         templatia::TemplateError::Parse(msg) => {
             assert!(msg.contains("Failed to parse field \"port\""));
@@ -65,7 +65,7 @@ fn duplicate_placeholder_inconsistent_values() {
     }
 
     let bad = "name=alice&again=bob";
-    let err = S::from_string(bad).expect_err("expected inconsistency error");
+    let err = S::from_str(bad).expect_err("expected inconsistency error");
     match err {
         templatia::TemplateError::InconsistentValues {
             placeholder,
@@ -89,7 +89,7 @@ fn duplicate_placeholder_equal_values_ok() {
     }
 
     let ok = "name=alice&again=alice";
-    let parsed = S::from_string(ok).expect("should parse when duplicates equal");
+    let parsed = S::from_str(ok).expect("should parse when duplicates equal");
     assert_eq!(
         parsed,
         S {

--- a/templatia-derive/tests/option_tests.rs
+++ b/templatia-derive/tests/option_tests.rs
@@ -18,10 +18,10 @@ mod basic_option_tests {
             name: Some("Alice".into()),
         };
 
-        let template = with_name.to_string();
+        let template = with_name.render_string();
         assert_eq!(template, "name=Alice");
 
-        let parsed = OptionalName::from_string(&template).unwrap();
+        let parsed = OptionalName::from_str(&template).unwrap();
         assert_eq!(parsed, with_name);
         assert_eq!(parsed.name, Some("Alice".into()));
     }
@@ -40,10 +40,10 @@ mod basic_option_tests {
             name: Some("test".into()),
         };
 
-        let template = instance.to_string();
+        let template = instance.render_string();
         assert_eq!(template, "id=42");
 
-        let parsed = OptionalFields::from_string(&template).unwrap();
+        let parsed = OptionalFields::from_str(&template).unwrap();
         assert_eq!(parsed.id, 42);
         assert_eq!(parsed.name, None); // Optional field not in template should be None
     }
@@ -64,8 +64,8 @@ mod basic_option_tests {
             email: Some("test@example.com".into()),
         };
 
-        let template = instance.to_string();
-        let parsed = MixedFields::from_string(&template).unwrap();
+        let template = instance.render_string();
+        let parsed = MixedFields::from_str(&template).unwrap();
 
         assert_eq!(parsed.id, 100);
         assert_eq!(parsed.name, ""); // Non-optional gets Default
@@ -88,10 +88,10 @@ mod basic_option_tests {
             email: Some("bob@example.com".into()),
         };
 
-        let template = instance.to_string();
+        let template = instance.render_string();
         assert_eq!(template, "name=Bob");
 
-        let parsed = MultipleOptional::from_string(&template).unwrap();
+        let parsed = MultipleOptional::from_str(&template).unwrap();
         assert_eq!(parsed.name, Some("Bob".into()));
         assert_eq!(parsed.age, None);
         assert_eq!(parsed.email, None);
@@ -111,10 +111,10 @@ mod basic_option_tests {
             age: Some(30),
         };
 
-        let template = instance.to_string();
+        let template = instance.render_string();
         assert_eq!(template, "name=Charlie, age=30");
 
-        let parsed = AllPresent::from_string(&template).unwrap();
+        let parsed = AllPresent::from_str(&template).unwrap();
         assert_eq!(parsed, instance);
         assert_eq!(parsed.name, Some("Charlie".into()));
         assert_eq!(parsed.age, Some(30));
@@ -130,11 +130,11 @@ mod basic_option_tests {
 
         // When serializing None, it should still produce the template format
         let with_none = OptionalValue { value: None };
-        let _template = with_none.to_string();
+        let _template = with_none.render_string();
         // The None value will be serialized as empty string or similar
         
         // But parsing from a valid template should give Some
-        let parsed = OptionalValue::from_string("value=test").unwrap();
+        let parsed = OptionalValue::from_str("value=test").unwrap();
         assert_eq!(parsed.value, Some("test".into()));
     }
 }
@@ -155,8 +155,8 @@ mod option_type_tests {
             text: Some("hello world".into()),
         };
 
-        let template = instance.to_string();
-        let parsed = OptionalString::from_string(&template).unwrap();
+        let template = instance.render_string();
+        let parsed = OptionalString::from_str(&template).unwrap();
         assert_eq!(parsed, instance);
     }
 
@@ -178,8 +178,8 @@ mod option_type_tests {
             i32_val: Some(-2147483648),
         };
 
-        let template = instance.to_string();
-        let parsed = OptionalNumerics::from_string(&template).unwrap();
+        let template = instance.render_string();
+        let parsed = OptionalNumerics::from_str(&template).unwrap();
         assert_eq!(parsed, instance);
     }
 
@@ -192,17 +192,17 @@ mod option_type_tests {
         }
 
         let with_true = OptionalBool { flag: Some(true) };
-        let template_true = with_true.to_string();
+        let template_true = with_true.render_string();
         assert_eq!(template_true, "flag=true");
 
-        let parsed_true = OptionalBool::from_string(&template_true).unwrap();
+        let parsed_true = OptionalBool::from_str(&template_true).unwrap();
         assert_eq!(parsed_true, with_true);
 
         let with_false = OptionalBool { flag: Some(false) };
-        let template_false = with_false.to_string();
+        let template_false = with_false.render_string();
         assert_eq!(template_false, "flag=false");
 
-        let parsed_false = OptionalBool::from_string(&template_false).unwrap();
+        let parsed_false = OptionalBool::from_str(&template_false).unwrap();
         assert_eq!(parsed_false, with_false);
     }
 
@@ -215,10 +215,10 @@ mod option_type_tests {
         }
 
         let instance = OptionalChar { ch: Some('X') };
-        let template = instance.to_string();
+        let template = instance.render_string();
         assert_eq!(template, "ch=X");
 
-        let parsed = OptionalChar::from_string(&template).unwrap();
+        let parsed = OptionalChar::from_str(&template).unwrap();
         assert_eq!(parsed, instance);
     }
 
@@ -236,8 +236,8 @@ mod option_type_tests {
             f64_val: Some(std::f64::consts::E),
         };
 
-        let template = instance.to_string();
-        let parsed = OptionalFloats::from_string(&template).unwrap();
+        let template = instance.render_string();
+        let parsed = OptionalFloats::from_str(&template).unwrap();
         
         assert!((parsed.f32_val.unwrap() - 3.14).abs() < 1e-5);
         assert!((parsed.f64_val.unwrap() - std::f64::consts::E).abs() < 1e-10);
@@ -260,10 +260,10 @@ mod option_complex_tests {
             id: Some("value".into()),
         };
 
-        let template = instance.to_string();
+        let template = instance.render_string();
         assert_eq!(template, "first=value, second=value");
 
-        let parsed = DuplicateOptional::from_string(&template).unwrap();
+        let parsed = DuplicateOptional::from_str(&template).unwrap();
         assert_eq!(parsed, instance);
     }
 
@@ -275,7 +275,7 @@ mod option_complex_tests {
             val: Option<String>,
         }
 
-        let result = DuplicateCheck::from_string("a=first, b=second");
+        let result = DuplicateCheck::from_str("a=first, b=second");
         
         match result {
             Err(TemplateError::InconsistentValues {
@@ -305,10 +305,10 @@ mod option_complex_tests {
             second: Some('B'),
         };
 
-        let template = instance.to_string();
+        let template = instance.render_string();
         assert_eq!(template, "AB");
 
-        let parsed = ConsecutiveOptionalChars::from_string(&template).unwrap();
+        let parsed = ConsecutiveOptionalChars::from_str(&template).unwrap();
         assert_eq!(parsed, instance);
     }
 
@@ -326,10 +326,10 @@ mod option_complex_tests {
             flag2: Some(false),
         };
 
-        let template = instance.to_string();
+        let template = instance.render_string();
         assert_eq!(template, "truefalse");
 
-        let parsed = ConsecutiveOptionalBools::from_string(&template).unwrap();
+        let parsed = ConsecutiveOptionalBools::from_str(&template).unwrap();
         assert_eq!(parsed, instance);
     }
 
@@ -349,15 +349,15 @@ mod option_complex_tests {
             path: Some("api/v1".into()),
         };
 
-        let template = full_url.to_string();
+        let template = full_url.render_string();
         assert_eq!(template, "https://example.com:8080/api/v1");
 
-        let parsed = OptionalUrl::from_string(&template).unwrap();
+        let parsed = OptionalUrl::from_str(&template).unwrap();
         assert_eq!(parsed, full_url);
 
         // Test with only required field
         let minimal_template = "https://example.com:80/";
-        let parsed_minimal = OptionalUrl::from_string(minimal_template).unwrap();
+        let parsed_minimal = OptionalUrl::from_str(minimal_template).unwrap();
         assert_eq!(parsed_minimal.host, "example.com");
         assert_eq!(parsed_minimal.port, Some(80));
         // New behavior: empty string path is parsed as None
@@ -380,10 +380,10 @@ mod option_complex_tests {
             email: Some("alice@example.com".into()),
         };
 
-        let template = person.to_string();
+        let template = person.render_string();
         assert_eq!(template, r#"{"name": "Alice", "age": 30}"#);
 
-        let parsed = OptionalPerson::from_string(&template).unwrap();
+        let parsed = OptionalPerson::from_str(&template).unwrap();
         assert_eq!(parsed.name, "Alice");
         assert_eq!(parsed.age, Some(30));
         assert_eq!(parsed.email, None); // Not in template
@@ -406,12 +406,12 @@ mod option_roundtrip_tests {
             data: Some("test_value".into()),
         };
 
-        let template1 = original.to_string();
-        let parsed1 = SimpleOptional::from_string(&template1).unwrap();
+        let template1 = original.render_string();
+        let parsed1 = SimpleOptional::from_str(&template1).unwrap();
         assert_eq!(parsed1, original);
 
-        let template2 = parsed1.to_string();
-        let parsed2 = SimpleOptional::from_string(&template2).unwrap();
+        let template2 = parsed1.render_string();
+        let parsed2 = SimpleOptional::from_str(&template2).unwrap();
         assert_eq!(parsed2, original);
 
         assert_eq!(template1, template2);
@@ -431,16 +431,16 @@ mod option_roundtrip_tests {
             optional_field: Some("ignored".into()),
         };
 
-        let template1 = original.to_string();
-        let parsed1 = WithOptional::from_string(&template1).unwrap();
+        let template1 = original.render_string();
+        let parsed1 = WithOptional::from_str(&template1).unwrap();
         
         assert_eq!(parsed1.id, 42);
         assert_eq!(parsed1.optional_field, None);
 
-        let template2 = parsed1.to_string();
+        let template2 = parsed1.render_string();
         assert_eq!(template1, template2);
 
-        let parsed2 = WithOptional::from_string(&template2).unwrap();
+        let parsed2 = WithOptional::from_str(&template2).unwrap();
         assert_eq!(parsed2, parsed1);
     }
 
@@ -460,8 +460,8 @@ mod option_roundtrip_tests {
 
         let mut current = original.clone();
         for _ in 0..5 {
-            let template = current.to_string();
-            current = MultiOptional::from_string(&template).unwrap();
+            let template = current.render_string();
+            current = MultiOptional::from_str(&template).unwrap();
         }
 
         assert_eq!(current, original);
@@ -481,7 +481,7 @@ mod option_error_tests {
         }
 
         // New behavior: invalid values for Option<T> become None instead of error
-        let result = OptionalPort::from_string("port=invalid");
+        let result = OptionalPort::from_str("port=invalid");
         match result {
             Ok(_) => panic!("Expected Parse error, got Ok"),
             Err(TemplateError::Parse(msg)) => {
@@ -499,7 +499,7 @@ mod option_error_tests {
             flag: Option<bool>,
         }
 
-        let result = OptionalFlag::from_string("flag=maybe");
+        let result = OptionalFlag::from_str("flag=maybe");
         
         match result {
             Err(TemplateError::Parse(msg)) => {
@@ -532,10 +532,10 @@ mod option_mixed_tests {
             optional_age: Some(25),
         };
 
-        let template = config.to_string();
+        let template = config.render_string();
         assert_eq!(template, "id=1, name=Test");
 
-        let parsed = MixedConfig::from_string(&template).unwrap();
+        let parsed = MixedConfig::from_str(&template).unwrap();
         assert_eq!(parsed.id, 1);
         assert_eq!(parsed.name, "Test");
         assert_eq!(parsed.optional_email, None);
@@ -558,8 +558,8 @@ mod option_mixed_tests {
             c: Some(true),
         };
 
-        let template = instance.to_string();
-        let parsed = AllOptional::from_string(&template).unwrap();
+        let template = instance.render_string();
+        let parsed = AllOptional::from_str(&template).unwrap();
         
         assert_eq!(parsed.a, Some("value".into()));
         assert_eq!(parsed.b, None);
@@ -579,10 +579,10 @@ mod option_mixed_tests {
             optional: Some("maybe".into()),
         };
 
-        let template = instance.to_string();
+        let template = instance.render_string();
         assert_eq!(template, "required = must_have\noptional = maybe");
 
-        let parsed = DefaultWithOptional::from_string(&template).unwrap();
+        let parsed = DefaultWithOptional::from_str(&template).unwrap();
         assert_eq!(parsed, instance);
     }
 
@@ -604,10 +604,10 @@ mod option_mixed_tests {
             d: "D".into(),
         };
 
-        let template = instance.to_string();
+        let template = instance.render_string();
         assert_eq!(template, "A-B-3");
 
-        let parsed = VariousPositions::from_string(&template).unwrap();
+        let parsed = VariousPositions::from_str(&template).unwrap();
         assert_eq!(parsed.a, Some("A".into()));
         assert_eq!(parsed.b, "B");
         assert_eq!(parsed.c, Some(3));
@@ -623,7 +623,7 @@ mod option_mixed_tests {
         }
 
         let template = "prefix=";
-        let parsed = EmptyOptional::from_string(template).unwrap();
+        let parsed = EmptyOptional::from_str(template).unwrap();
         // New behavior: empty string is parsed as None by default
         assert_eq!(parsed.value, None);
     }
@@ -655,10 +655,10 @@ mod option_mixed_tests {
             timeout: Some(30),
         };
 
-        let template = config.to_string();
+        let template = config.render_string();
         assert_eq!(template, "Server: localhost:5432 | DB: mydb");
 
-        let parsed = ServerConfig::from_string(&template).unwrap();
+        let parsed = ServerConfig::from_str(&template).unwrap();
         assert_eq!(parsed.host, "localhost");
         assert_eq!(parsed.port, 5432);
         assert_eq!(parsed.database, "mydb");
@@ -682,7 +682,7 @@ mod empty_str_option_not_none_tests {
         }
 
         let template = "prefix=";
-        let parsed = EmptyAsIs::from_string(template).unwrap();
+        let parsed = EmptyAsIs::from_str(template).unwrap();
         assert_eq!(parsed.value, Some("".into()));
     }
 
@@ -695,7 +695,7 @@ mod empty_str_option_not_none_tests {
         }
 
         let template = "prefix=";
-        let parsed = EmptyAsNone::from_string(template).unwrap();
+        let parsed = EmptyAsNone::from_str(template).unwrap();
         assert_eq!(parsed.value, None);
     }
 
@@ -708,7 +708,7 @@ mod empty_str_option_not_none_tests {
         }
 
         let template = "prefix=test";
-        let parsed = NonEmpty::from_string(template).unwrap();
+        let parsed = NonEmpty::from_str(template).unwrap();
         assert_eq!(parsed.value, Some("test".into()));
     }
 
@@ -722,7 +722,7 @@ mod empty_str_option_not_none_tests {
         }
 
         let template = "a=, b=value";
-        let parsed = MultipleOptionals::from_string(template).unwrap();
+        let parsed = MultipleOptionals::from_str(template).unwrap();
         assert_eq!(parsed.a, Some("".into()));
         assert_eq!(parsed.b, Some("value".into()));
     }
@@ -739,10 +739,10 @@ mod empty_str_option_not_none_tests {
             data: Some("".into()),
         };
 
-        let template = original.to_string();
+        let template = original.render_string();
         assert_eq!(template, "data=");
 
-        let parsed = RoundtripTest::from_string(&template).unwrap();
+        let parsed = RoundtripTest::from_str(&template).unwrap();
         assert_eq!(parsed.data, Some("".into()));
     }
 
@@ -756,7 +756,7 @@ mod empty_str_option_not_none_tests {
         }
 
         let template = "text=, num=42";
-        let parsed = MixedTypes::from_string(template).unwrap();
+        let parsed = MixedTypes::from_str(template).unwrap();
         assert_eq!(parsed.text, Some("".into()));
         assert_eq!(parsed.num, Some(42));
     }
@@ -771,7 +771,7 @@ mod empty_str_option_not_none_tests {
         }
 
         let template = "a=";
-        let parsed = WithMissing::from_string(template).unwrap();
+        let parsed = WithMissing::from_str(template).unwrap();
         assert_eq!(parsed.a, Some("".into()));
         assert_eq!(parsed.b, None); // Not in template
     }
@@ -795,10 +795,10 @@ mod consecutive_option_placeholder_tests {
             second: Some('B'),
         };
 
-        let template = chars.to_string();
+        let template = chars.render_string();
         assert_eq!(template, "AB");
 
-        let parsed = ConsecutiveOptionChars::from_string(&template).unwrap();
+        let parsed = ConsecutiveOptionChars::from_str(&template).unwrap();
         assert_eq!(parsed, chars);
     }
 
@@ -816,10 +816,10 @@ mod consecutive_option_placeholder_tests {
             flag2: Some(false),
         };
 
-        let template = bools.to_string();
+        let template = bools.render_string();
         assert_eq!(template, "truefalse");
 
-        let parsed = ConsecutiveOptionBools::from_string(&template).unwrap();
+        let parsed = ConsecutiveOptionBools::from_str(&template).unwrap();
         assert_eq!(parsed, bools);
     }
 
@@ -837,10 +837,10 @@ mod consecutive_option_placeholder_tests {
             flag: Some(true),
         };
 
-        let template = mixed.to_string();
+        let template = mixed.render_string();
         assert_eq!(template, "Xtrue");
 
-        let parsed = MixedOptionTypes::from_string(&template).unwrap();
+        let parsed = MixedOptionTypes::from_str(&template).unwrap();
         assert_eq!(parsed, mixed);
     }
 
@@ -858,10 +858,10 @@ mod consecutive_option_placeholder_tests {
             req_bool: false,
         };
 
-        let template = mixed.to_string();
+        let template = mixed.render_string();
         assert_eq!(template, "Tfalse");
 
-        let parsed = OptionAndRequired::from_string(&template).unwrap();
+        let parsed = OptionAndRequired::from_str(&template).unwrap();
         assert_eq!(parsed, mixed);
     }
 
@@ -881,10 +881,10 @@ mod consecutive_option_placeholder_tests {
             c: Some('Z'),
         };
 
-        let template = multi.to_string();
+        let template = multi.render_string();
         assert_eq!(template, "XYZ");
 
-        let parsed = MultipleOptionChars::from_string(&template).unwrap();
+        let parsed = MultipleOptionChars::from_str(&template).unwrap();
         assert_eq!(parsed, multi);
     }
 }
@@ -908,10 +908,10 @@ mod option_default_template_tests {
             active: Some(true),
         };
 
-        let template = instance.to_string();
+        let template = instance.render_string();
         assert_eq!(template, "name = Alice\nage = 30\nactive = true");
 
-        let parsed = AllOptionalFields::from_string(&template).unwrap();
+        let parsed = AllOptionalFields::from_str(&template).unwrap();
         assert_eq!(parsed, instance);
     }
 
@@ -928,10 +928,10 @@ mod option_default_template_tests {
             count: None,
         };
 
-        let template = instance.to_string();
+        let template = instance.render_string();
         assert_eq!(template, "name = \ncount = ");
 
-        let parsed = WithNoneValues::from_string(&template).unwrap();
+        let parsed = WithNoneValues::from_str(&template).unwrap();
         assert_eq!(parsed.name, None);
         assert_eq!(parsed.count, None);
     }
@@ -951,10 +951,10 @@ mod option_default_template_tests {
             c: Some(false),
         };
 
-        let template = instance.to_string();
+        let template = instance.render_string();
         assert_eq!(template, "a = value\nb = \nc = false");
 
-        let parsed = MixedSomeNone::from_string(&template).unwrap();
+        let parsed = MixedSomeNone::from_str(&template).unwrap();
         assert_eq!(parsed.a, Some("value".into()));
         assert_eq!(parsed.b, None);
         assert_eq!(parsed.c, Some(false));
@@ -973,10 +973,10 @@ mod option_default_template_tests {
             optional: Some("maybe".into()),
         };
 
-        let template = instance.to_string();
+        let template = instance.render_string();
         assert_eq!(template, "required = must_have\noptional = maybe");
 
-        let parsed = MixedOptionalRequired::from_string(&template).unwrap();
+        let parsed = MixedOptionalRequired::from_str(&template).unwrap();
         assert_eq!(parsed, instance);
     }
 
@@ -995,10 +995,10 @@ mod option_default_template_tests {
             c: None,
         };
 
-        let template = instance.to_string();
+        let template = instance.render_string();
         assert_eq!(template, "a = \nb = \nc = ");
 
-        let parsed = AllNone::from_string(&template).unwrap();
+        let parsed = AllNone::from_str(&template).unwrap();
         assert_eq!(parsed, instance);
     }
 }

--- a/templatia/src/lib.rs
+++ b/templatia/src/lib.rs
@@ -446,11 +446,9 @@ pub trait Template where Self: Sized {
     /// defined template rules. The output should be parseable by `from_str`
     /// to maintain round-trip consistency.
     ///
-    /// # Performance Notes
+    /// # Returns
     ///
-    /// This method creates a new `String` on each call. For performance-critical
-    /// applications with frequent serialization, consider caching results or using
-    /// streaming approaches.
+    /// - String: The fully rendered template output that corresponds to the defined template or manual implemented result.
     ///
     /// # Examples
     ///

--- a/templatia/src/lib.rs
+++ b/templatia/src/lib.rs
@@ -334,7 +334,9 @@ pub use templatia_derive::Template;
 ///
 /// When manually implementing this trait:
 ///
-/// 1. **Consistency**: Ensure `from_str(x.to_string())` equals `x` for valid data
+/// 1. **Consistency**: Ensure `from_str(x.render_string())` equals `x` for valid data
+///    - In `empty_str_option_not_none` mode, we have the known limitation that
+///      the consistency breaks like `None` is treated as `Some("")`
 /// 2. **Error Handling**: Use descriptive error messages that help users debug issues
 /// 3. **Performance**: Consider caching compiled parsers for repeated use
 /// 4. **Validation**: Validate data integrity, especially with duplicate placeholders

--- a/templatia/src/lib.rs
+++ b/templatia/src/lib.rs
@@ -41,11 +41,11 @@
 //! };
 //!
 //! // Convert to template string (default format: field = {field})
-//! let template = config.to_string();
+//! let template = config.render_string();
 //! assert_eq!(template, "host = localhost\nport = 5432\ndatabase = myapp");
 //!
 //! // Parse back from template string
-//! let parsed = DatabaseConfig::from_string(&template).unwrap();
+//! let parsed = DatabaseConfig::from_str(&template).unwrap();
 //! assert_eq!(parsed.host, "localhost");
 //! assert_eq!(parsed.port, 5432);
 //! ```
@@ -71,9 +71,9 @@
 //!     database: "production".to_string(),
 //! };
 //!
-//! assert_eq!(url.to_string(), "postgresql://db.example.com:5432/production");
+//! assert_eq!(url.render_string(), "postgresql://db.example.com:5432/production");
 //!
-//! let parsed = PostgresUrl::from_string("postgresql://localhost:5432/test").unwrap();
+//! let parsed = PostgresUrl::from_str("postgresql://localhost:5432/test").unwrap();
 //! assert_eq!(parsed.database, "test");
 //! ```
 //!
@@ -92,11 +92,83 @@
 //! }
 //!
 //! let greeting = Greeting { name: "Alice".to_string() };
-//! assert_eq!(greeting.to_string(), "Welcome Alice! Your name is Alice.");
+//! assert_eq!(greeting.render_string(), "Welcome Alice! Your name is Alice.");
 //!
 //! // Parsing with inconsistent values will result in an error
-//! let result = Greeting::from_string("Welcome Alice! Your name is Bob.");
+//! let result = Greeting::from_str("Welcome Alice! Your name is Bob.");
 //! assert!(result.is_err());
+//! ```
+//!
+//! #### Option<T> Support
+//! Fields with `Option<T>` type automatically default to `None` when the placeholder is not in the template:
+//!
+//! ```rust
+//! use templatia::Template;
+//!
+//! #[derive(Template)]
+//! #[templatia(template = "host={host}:{port}", allow_missing_placeholders)]
+//! struct ServerConfig {
+//!     host: String,
+//!     port: u16,
+//!     username: Option<String>,
+//!     password: Option<String>,
+//! }
+//!
+//! let config = ServerConfig::from_str("host=localhost:8080").unwrap();
+//! assert_eq!(config.host, "localhost");
+//! assert_eq!(config.port, 8080);
+//! assert_eq!(config.username, None); // Not in template, defaults to None
+//! assert_eq!(config.password, None); // Not in template, defaults to None
+//! ```
+//!
+//! By default, empty strings in `Option<String>` are parsed as `None`:
+//!
+//! ```rust
+//! use templatia::Template;
+//!
+//! #[derive(Template)]
+//! #[templatia(template = "value={value}")]
+//! struct OptionalValue {
+//!     value: Option<String>,
+//! }
+//!
+//! let parsed = OptionalValue::from_str("value=").unwrap();
+//! assert_eq!(parsed.value, None); // Empty string becomes None
+//! ```
+//!
+//! To treat empty strings as `Some("")`, use the `empty_str_option_not_none` attribute:
+//!
+//! ```rust
+//! use templatia::Template;
+//!
+//! #[derive(Template)]
+//! #[templatia(template = "value={value}", empty_str_option_not_none)]
+//! struct OptionalValue {
+//!     value: Option<String>,
+//! }
+//!
+//! let parsed = OptionalValue::from_str("value=").unwrap();
+//! assert_eq!(parsed.value, Some("".to_string())); // Empty string becomes Some("")
+//! ```
+//!
+//! #### Missing Placeholders
+//! Use `allow_missing_placeholders` to allow fields not in the template:
+//!
+//! ```rust
+//! use templatia::Template;
+//!
+//! #[derive(Template)]
+//! #[templatia(template = "id={id}", allow_missing_placeholders)]
+//! struct Config {
+//!     id: u32,
+//!     name: String,           // Not in template, uses Default::default()
+//!     optional: Option<u32>,  // Not in template, becomes None
+//! }
+//!
+//! let config = Config::from_str("id=42").unwrap();
+//! assert_eq!(config.id, 42);
+//! assert_eq!(config.name, "");          // Default for String
+//! assert_eq!(config.optional, None);     // None for Option<T>
 //! ```
 //!
 //! ### Manual Implementation (Advanced)
@@ -112,13 +184,12 @@
 //!
 //! impl Template for Point {
 //!     type Error = TemplateError;
-//!     type Struct = Point;
 //!
-//!     fn to_string(&self) -> String {
+//!     fn render_string(&self) -> String {
 //!         format!("({}, {})", self.0, self.1)
 //!     }
 //!
-//!     fn from_string(s: &str) -> Result<Self::Struct, Self::Error> {
+//!     fn from_str(s: &str) -> Result<Self, Self::Error> {
 //!         if !s.starts_with('(') || !s.ends_with(')') {
 //!             return Err(TemplateError::Parse("Expected format: (x, y)".to_string()));
 //!         }
@@ -140,9 +211,9 @@
 //! }
 //!
 //! let point = Point(10, 20);
-//! assert_eq!(point.to_string(), "(10, 20)");
+//! assert_eq!(point.render_string(), "(10, 20)");
 //!
-//! let parsed = Point::from_string("(5, 15)").unwrap();
+//! let parsed = Point::from_str("(5, 15)").unwrap();
 //! assert_eq!(parsed.0, 5);
 //! assert_eq!(parsed.1, 15);
 //! ```
@@ -151,11 +222,13 @@
 //!
 //! Templatia follows a clear development roadmap with planned features:
 //!
-//! ### 🚧 Version 0.0.2
-//! - Enhanced error handling with warnings for missing fields
-//! - Configurable default behavior for missing data
-//! - `Option<T>` support (defaults to `None` when placeholder absent)
-//! - String field configuration for missing placeholders
+//! ### ✅ Version 0.0.2 (Completed)
+//! - `#[templatia(allow_missing_placeholders)]` attribute: Fields not in template use `Default::default()`
+//! - `Option<T>` support: Automatically defaults to `None` when placeholder is absent
+//! - Empty string handling: By default, empty strings in `Option<String>` are parsed as `None`
+//! - `#[templatia(empty_str_option_not_none)]` attribute: Treats empty strings as `Some("")` instead of `None`
+//! - Removed `type Struct` associated type from `Template` trait (simplified to `Self`)
+//! - Bug fixes for consistent placeholder handling and parsing edge cases
 //!
 //! ### 🔮 Version 0.0.3
 //! - Enriched error diagnostics and coverage
@@ -191,7 +264,7 @@
 //! struct Config { port: u16 }
 //!
 //! // Parse error example
-//! match Config::from_string("port=not_a_number") {
+//! match Config::from_str("port=not_a_number") {
 //!     Err(TemplateError::Parse(msg)) => println!("Parse failed: {}", msg),
 //!     _ => unreachable!(),
 //! }
@@ -201,7 +274,7 @@
 //! #[templatia(template = "id={id}-backup-{id}")]
 //! struct BackupConfig { id: String }
 //!
-//! match BackupConfig::from_string("id=prod-backup-dev") {
+//! match BackupConfig::from_str("id=prod-backup-dev") {
 //!     Err(TemplateError::InconsistentValues { placeholder, first_value, second_value }) => {
 //!         println!("Placeholder '{}' had conflicting values: '{}' vs '{}'",
 //!                  placeholder, first_value, second_value);
@@ -256,14 +329,12 @@ pub use templatia_derive::Template;
 ///
 /// - `Error`: The concrete error type returned by parsing operations. Should implement
 ///   `std::error::Error + std::fmt::Display` for best integration with error handling.
-/// - `Struct`: The concrete struct type produced by `from_string`. This allows the trait
-///   to work with generic implementations while maintaining type safety.
 ///
 /// # Implementation Guidelines
 ///
 /// When manually implementing this trait:
 ///
-/// 1. **Consistency**: Ensure `from_string(x.to_string())` equals `x` for valid data
+/// 1. **Consistency**: Ensure `from_str(x.to_string())` equals `x` for valid data
 /// 2. **Error Handling**: Use descriptive error messages that help users debug issues
 /// 3. **Performance**: Consider caching compiled parsers for repeated use
 /// 4. **Validation**: Validate data integrity, especially with duplicate placeholders
@@ -282,13 +353,12 @@ pub use templatia_derive::Template;
 ///
 /// impl Template for ServerConfig {
 ///     type Error = TemplateError;
-///     type Struct = ServerConfig;
 ///
-///     fn to_string(&self) -> String {
+///     fn render_string(&self) -> String {
 ///         format!("server={},port={}", self.name, self.port)
 ///     }
 ///
-///     fn from_string(s: &str) -> Result<Self::Struct, Self::Error> {
+///     fn from_str(s: &str) -> Result<Self, Self::Error> {
 ///         let parts: Vec<&str> = s.split(',').collect();
 ///         if parts.len() != 2 {
 ///             return Err(TemplateError::Parse("Expected format: server=name,port=number".to_string()));
@@ -309,10 +379,10 @@ pub use templatia_derive::Template;
 /// }
 ///
 /// let config = ServerConfig { name: "web01".to_string(), port: 8080 };
-/// let template = config.to_string();
+/// let template = config.render_string();
 /// assert_eq!(template, "server=web01,port=8080");
 ///
-/// let parsed = ServerConfig::from_string(&template).unwrap();
+/// let parsed = ServerConfig::from_str(&template).unwrap();
 /// assert_eq!(parsed.name, "web01");
 /// assert_eq!(parsed.port, 8080);
 /// ```
@@ -335,13 +405,12 @@ pub use templatia_derive::Template;
 ///     T::Err: Display,
 /// {
 ///     type Error = TemplateError;
-///     type Struct = KeyValue<T>;
 ///
-///     fn to_string(&self) -> String {
+///     fn render_string(&self) -> String {
 ///         format!("{}={}", self.key, self.value)
 ///     }
 ///
-///     fn from_string(s: &str) -> Result<Self::Struct, Self::Error> {
+///     fn from_str(s: &str) -> Result<Self, Self::Error> {
 ///         let parts: Vec<&str> = s.splitn(2, '=').collect();
 ///         if parts.len() != 2 {
 ///             return Err(TemplateError::Parse("Expected key=value format".to_string()));
@@ -356,12 +425,12 @@ pub use templatia_derive::Template;
 /// }
 ///
 /// let config = KeyValue { key: "timeout".to_string(), value: 30u32 };
-/// assert_eq!(config.to_string(), "timeout=30");
+/// assert_eq!(config.render_string(), "timeout=30");
 ///
-/// let parsed = KeyValue::<u32>::from_string("retry=5").unwrap();
+/// let parsed = KeyValue::<u32>::from_str("retry=5").unwrap();
 /// assert_eq!(parsed.value, 5);
 /// ```
-pub trait Template {
+pub trait Template where Self: Sized {
     /// The concrete error type for template parsing or formatting failures.
     ///
     /// This should typically be `TemplateError` for most implementations, but custom
@@ -369,17 +438,10 @@ pub trait Template {
     /// implement `std::error::Error` for best integration with Rust's error ecosystem.
     type Error;
 
-    /// The concrete struct type created by `from_string`.
-    ///
-    /// This is usually the same as `Self`, but using an associated type allows for
-    /// more flexible implementations, particularly with generic types or when the
-    /// parsing result might differ from the input type.
-    type Struct;
-
     /// Converts the value into its template string representation.
     ///
     /// This method serializes the struct into a string format according to the
-    /// defined template rules. The output should be parseable by `from_string`
+    /// defined template rules. The output should be parseable by `from_str`
     /// to maintain round-trip consistency.
     ///
     /// # Performance Notes
@@ -404,17 +466,17 @@ pub trait Template {
     ///     debug: true,
     /// };
     ///
-    /// let template = config.to_string();
+    /// let template = config.render_string();
     /// // Default format: "name = myapp\ndebug = true"
     /// assert!(template.contains("name = myapp"));
     /// assert!(template.contains("debug = true"));
     /// ```
-    fn to_string(&self) -> String;
+    fn render_string(&self) -> String;
 
     /// Parses an instance from a template string.
     ///
     /// This method deserializes a string into the target struct type according to
-    /// the defined template rules. It should be the inverse operation of `to_string`.
+    /// the defined template rules. It should be the inverse operation of `render_string`.
     ///
     /// # Parameters
     ///
@@ -422,7 +484,7 @@ pub trait Template {
     ///
     /// # Returns
     ///
-    /// On success, returns a constructed instance of `Self::Struct`. The result
+    /// On success, returns a constructed instance of `Self`. The result
     /// should be equivalent to the original struct that generated the string.
     ///
     /// # Errors
@@ -446,19 +508,19 @@ pub trait Template {
     /// }
     ///
     /// // Successful parsing
-    /// let conn = Connection::from_string("host=localhost:8080").unwrap();
+    /// let conn = Connection::from_str("host=localhost:8080").unwrap();
     /// assert_eq!(conn.host, "localhost");
     /// assert_eq!(conn.port, 8080);
     ///
     /// // Error handling
-    /// match Connection::from_string("host=localhost:invalid_port") {
+    /// match Connection::from_str("host=localhost:invalid_port") {
     ///     Err(TemplateError::Parse(msg)) => {
     ///         println!("Parsing failed: {}", msg);
     ///     }
     ///     _ => panic!("Expected parse error"),
     /// }
     /// ```
-    fn from_string(s: &str) -> Result<Self::Struct, Self::Error>;
+    fn from_str(s: &str) -> Result<Self, Self::Error>;
 }
 
 /// Errors produced by templatia operations.


### PR DESCRIPTION
# refactor: rename template methods for consistency and update related tests

- Rename `to_string` to `render_string` and `from_string` to `from_str` for clarity
- Update tests to reflect these method name changes
- Improve consistency across API and documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Optional-field handling: missing placeholders default to None for Option<T>.
  - New attributes: allow_missing_placeholders and empty_str_option_not_none.
  - Expanded validation and tests.

- Breaking Changes
  - Public API method names renamed: to_string → render_string, from_string → from_str.
  - Template parsing now returns Self; removed prior associated-type indirection.
  - Derive outputs updated to match new API.

- Bug Fixes
  - Improved placeholder handling edge cases.

- Documentation
  - README and changelog updated with v0.0.2 and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->