### PR TITLE
Update CHANGELOG.md for preparing release 0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,24 +2,27 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.0.2] - 2025-10-02
+## [0.0.2] - 2025-10-03
 ### Added
 - Support for Option<T>: When a placeholder is absent in the template, fields of type `Option<T>` automatically default to `None`.
 - New attribute `#[templatia(empty_str_option_not_none)]` to treat empty strings for `Option<String>` as `Some("")` instead of the default `None`.
 - New attribute `#[templatia(allow_missing_placeholders)]` to allow fields not present in the template; such fields are initialized with `Default::default()` (requires `Default` for those field types).
 - Compile-time validation to prevent ambiguous consecutive placeholders (e.g., consecutive `String`-like fields) and clearer diagnostics.
 - Extensive tests: comprehensive round-trip tests, option handling tests, manual implementation examples, and compile-fail cases.
+- New documentation: LIMITATION.md (current constraints) and ROADMAP_CHANGES.md (short-term roadmap). 
+- Documented MSRV: Rust 1.85.0 (Edition 2024).
 
 ### Changed
-- Documentation updates in README.md and README-ja.md to reflect new attributes, defaults, and examples.
+- Documentation updates in README.md and README-ja.md to reflect new attributes, defaults, and examples, including explicit description of default template generation when no template is provided.
 - Internal derive generator refactoring and utility/validator modules to support new parsing and validation logic.
+- Updated AGENTS.md to clarify testing and documentation conventions.
 
 ### Fixed
 - Improved and more consistent placeholder handling around edge cases during parsing.
 - Adjusted compile-fail tests for missing fields to reflect new validation behavior.
 
 ### Breaking Changes
-- Template trait API change: removed the associated type `type Struct`; `from_string` now returns `Self` instead of `Self::Struct`.
+- Template trait API change: removed the associated type `type Struct`; `from_str` now returns `Self` instead of `Self::Struct`.
   - All manual implementations must update their signatures accordingly.
   - The derive macro has been updated to generate the new signature.
 - Template method name change: `from_string` -> `from_str` and `to_string` -> `render_string`.


### PR DESCRIPTION
## docs: update changelog for version `0.0.2` with detailed additions and changes

- Include new documentation files: `LIMITATION.md` and `ROADMAP_CHANGES.md`
- Specify MSRV as Rust 1.85.0 (Edition 2024)
- Expand README updates with improved examples and default generation details
- Clarify testing and documentation conventions in `AGENTS.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Breaking Changes
  - Constructors renamed, with return types updated to the implementing type.
  - Rendering method renamed for clarity and consistency.
  - Template trait simplified by removing an associated type, streamlining implementations.
  - Derive macro updated to generate the new constructor and rendering method names.

- Documentation
  - Changelog updated to reflect API renames and trait simplifications, aiding migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->