### PR TITLE
Refactor the construction of the internal implementation to expand the future feature implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,7 +303,7 @@ checksum = "1ac9aa371f599d22256307c24a9d748c041e548cbf599f35d890f9d365361790"
 
 [[package]]
 name = "templatia"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "chumsky",
  "templatia-derive",
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "templatia-derive"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.0.2"
+version = "0.0.3"
 authors = ["SHIMA0111<shima@little-tabby.com>"]
 license = "MIT or Apache-2.0"
 readme = "README.md"

--- a/templatia-derive/src/error.rs
+++ b/templatia-derive/src/error.rs
@@ -1,0 +1,40 @@
+use crate::fields::FieldKind;
+use crate::utils::get_type_name;
+
+pub(crate) fn generate_compile_error(msg: &str) -> proc_macro2::TokenStream {
+    let error = syn::Error::new(proc_macro2::Span::call_site(), msg);
+    error.to_compile_error().into()
+}
+
+pub(crate) fn generate_unsupported_compile_error(field: &syn::Ident, ty: &FieldKind) -> proc_macro2::TokenStream {
+    let msg = format!(
+        "unsupported type field: {0} has a {1} type. currently, {1} is not supported.",
+        // Currently, support only named struct so this unwrap is safe.
+        field.to_string(),
+        match ty {
+            FieldKind::Result(ok_ty, err_ty) => format!(
+                "Result<{}, {}>", get_type_name(ok_ty), get_type_name(err_ty)
+            ),
+            FieldKind::Vec(ty) => format!(
+                "Vec<{}>", get_type_name(ty),
+            ),
+            FieldKind::HashSet(ty) => format!(
+                "HashSet<{}>", get_type_name(ty),
+            ),
+            FieldKind::BTreeSet(ty) => format!(
+                "BTreeSet<{}>", get_type_name(ty),
+            ),
+            FieldKind::HashMap(k_ty, v_ty) => format!(
+                "HashMap<{}, {}>", get_type_name(k_ty), get_type_name(v_ty),
+            ),
+            FieldKind::BTreeMap(k_ty, v_ty) => format!(
+                "BTreeMap<{}, {}>", get_type_name(k_ty), get_type_name(v_ty),
+            ),
+            FieldKind::Tuple => "tuple".to_string(),
+            FieldKind::Unknown => "cannot recognize the field".to_string(),
+            _ => unreachable!(),
+        }
+    );
+
+    generate_compile_error(&msg)
+}

--- a/templatia-derive/src/error.rs
+++ b/templatia-derive/src/error.rs
@@ -1,5 +1,5 @@
 use crate::fields::FieldKind;
-use crate::utils::get_type_name;
+use crate::utils::{get_type_name, CONSECUTIVE_PLACEHOLDER_ALLOWED_TYPE};
 
 pub(crate) fn generate_compile_error(msg: &str) -> proc_macro2::TokenStream {
     let error = syn::Error::new(proc_macro2::Span::call_site(), msg);
@@ -8,7 +8,7 @@ pub(crate) fn generate_compile_error(msg: &str) -> proc_macro2::TokenStream {
 
 pub(crate) fn generate_unsupported_compile_error(field: &syn::Ident, ty: &FieldKind) -> proc_macro2::TokenStream {
     let msg = format!(
-        "unsupported type field: {0} has a {1} type. currently, {1} is not supported.",
+        "unsupported type field: {0} has a {1} type. currently, {1} is not supported",
         // Currently, support only named struct so this unwrap is safe.
         field.to_string(),
         match ty {
@@ -35,6 +35,27 @@ pub(crate) fn generate_unsupported_compile_error(field: &syn::Ident, ty: &FieldK
             _ => unreachable!(),
         }
     );
+
+    generate_compile_error(&msg)
+}
+
+pub(crate) fn generate_consecutive_compile_error(
+    first_ph: &str,
+    second_ph: &str,
+    first_type: &str,
+) -> proc_macro2::TokenStream
+{
+    let msg = format!(
+        "placeholder \"{0}\" and \"{1}\" are consecutive. these cause ambiguity to parsing bound.\
+        \n\"{0}\" is `{2}` type data. Consecutive allows only: [{3}]",
+        first_ph, second_ph, first_type, CONSECUTIVE_PLACEHOLDER_ALLOWED_TYPE.join(", ")
+    );
+
+    generate_compile_error(&msg)
+}
+
+pub(crate) fn generate_not_found_placeholder_compile_error(struct_name: &str, ph: &str) -> proc_macro2::TokenStream {
+    let msg = format!("{} has no field named \"{}\"", struct_name, ph);
 
     generate_compile_error(&msg)
 }

--- a/templatia-derive/src/fields.rs
+++ b/templatia-derive/src/fields.rs
@@ -1,0 +1,177 @@
+use std::collections::{HashMap, HashSet};
+use syn::GenericArgument;
+
+// TODO: Add support for Result<T, E>, Collection<T>, KVCollection<K, V>
+#[allow(dead_code)]
+pub(crate) enum FieldKind<'a> {
+    Primitive(&'a syn::Type),
+    Option(&'a syn::Type),
+    Result(&'a syn::Type, &'a syn::Type),
+    Collection(&'a syn::Type),
+    KVCollection(&'a syn::Type, &'a syn::Type),
+    Tuple,
+    Unknown,
+}
+
+pub(crate) struct Fields<'a> {
+    fields: &'a [syn::Field],
+    idents_type: HashMap<&'a syn::Ident, FieldKind<'a>>,
+}
+
+impl<'a> Fields<'a> {
+    pub(crate) fn new(fields: &'a [syn::Field]) -> Self {
+        let idents_type = analyze_fields(fields);
+
+        Self { fields, idents_type }
+    }
+
+    pub(crate) fn get_type_kind_by_name(&'_ self, name: &str) -> Option<&'_ FieldKind<'_>> {
+        let name = proc_macro2::Ident::new(name, proc_macro2::Span::call_site());
+        self.idents_type.get(&name)
+    }
+
+    pub(crate) fn used_fields_in_template(&self, placeholders: &HashSet<String>) -> Vec<&syn::Field> {
+       self.fields
+            .iter()
+            .filter(|field| {
+                if let Some(ident) = field.ident.as_ref() {
+                    placeholders.contains(&ident.to_string())
+                } else {
+                    false
+                }
+            })
+            .collect::<Vec<_>>()
+    }
+
+    pub(crate) fn get_field_kind(&'_ self, ident: &syn::Ident) -> Option<&'_ FieldKind<'_>> {
+        self.idents_type.get(ident)
+    }
+
+    pub(crate) fn idents(&self) -> HashSet<&syn::Ident> {
+        self.fields.iter().filter_map(|f| f.ident.as_ref()).collect()
+    }
+
+    pub(crate) fn field_names(&self) -> HashSet<String> {
+        self.idents().iter().map(|ident| ident.to_string()).collect()
+    }
+
+    pub(crate) fn option_fields(&self) -> HashMap<&syn::Ident, &syn::Type> {
+        self.idents_type
+            .iter()
+            .filter(|(_, kind)| matches!(kind, FieldKind::Option(_)))
+            .map(|(&ident, kind)| {
+                let ty = match kind {
+                    FieldKind::Option(ty) => *ty,
+                    _ => unreachable!(),
+                };
+
+                (ident, ty)
+            })
+            .collect()
+    }
+
+    fn missing_placeholders(&self, placeholders_names: &HashSet<String>) -> Vec<&syn::Ident> {
+        self.idents()
+            .iter()
+            .filter(|ident| !placeholders_names.contains(&ident.to_string()))
+            .map(|ident| *ident)
+            .collect()
+    }
+
+    pub(crate) fn missing_placeholders_sep_opt(&self, placeholder_names: &HashSet<String>) -> (Vec<&syn::Ident>, Vec<&syn::Ident>) {
+        let mut missing_placeholders_sep_opt = Vec::new();
+        let mut missing_placeholders_sep_non_opt = Vec::new();
+
+        let option_fields = self.option_fields();
+
+        for missing_placeholder in self.missing_placeholders(placeholder_names) {
+            if option_fields.contains_key(missing_placeholder) {
+                missing_placeholders_sep_opt.push(missing_placeholder);
+            } else {
+                missing_placeholders_sep_non_opt.push(missing_placeholder);
+            }
+        }
+
+        (missing_placeholders_sep_opt, missing_placeholders_sep_non_opt)
+    }
+}
+
+fn analyze_fields(fields: &'_ [syn::Field]) -> HashMap<&'_ syn::Ident, FieldKind<'_>> {
+    let mut result = HashMap::new();
+
+    for field in fields {
+        // If the field is not named, skip it. Currently only named fields are supported.
+        if field.ident.is_none() {
+            continue;
+        }
+
+        match &field.ty {
+            syn::Type::Path(type_path) => {
+                if let Some(last_segment) = type_path.path.segments.last() {
+                    match &last_segment.arguments {
+                        syn::PathArguments::AngleBracketed(args) => {
+                            let ident = &last_segment.ident.to_string();
+                            match ident.as_str() {
+                                "Option" => {
+                                    // Option<T> has only one argument which is T.
+                                    if args.args.len() == 1 {
+                                        if let Some(GenericArgument::Type(ty)) = args.args.first() {
+                                            result.insert(field.ident.as_ref().unwrap(), FieldKind::Option(ty));
+                                            continue;
+                                        }
+                                    }
+                                    result.insert(field.ident.as_ref().unwrap(), FieldKind::Unknown);
+                                },
+                                "Vec" | "HashSet" | "BTreeSet" => {
+                                    // Vec<T>, HashSet<T>, BTreeSet<T> has only one argument which is T.
+                                    if args.args.len() == 1 {
+                                        if let Some(GenericArgument::Type(ty)) = args.args.first() {
+                                            result.insert(field.ident.as_ref().unwrap(), FieldKind::Collection(ty));
+                                            continue;
+                                        }
+                                    }
+                                    result.insert(field.ident.as_ref().unwrap(), FieldKind::Unknown);
+                                },
+                                "HashMap" | "BTreeMap" => {
+                                    if args.args.len() == 2 {
+                                        if let (Some(GenericArgument::Type(key_ty)), Some(GenericArgument::Type(value_ty))) = (args.args.first(), args.args.last()) {
+                                            result.insert(field.ident.as_ref().unwrap(), FieldKind::KVCollection(key_ty, value_ty));
+                                            continue;
+                                        }
+                                    }
+                                    result.insert(field.ident.as_ref().unwrap(), FieldKind::Unknown);
+                                },
+                                "Result" => {
+                                    if args.args.len() == 2 {
+                                        if let (Some(GenericArgument::Type(ok_ty)), Some(GenericArgument::Type(err_ty))) = (args.args.first(), args.args.last()) {
+                                            result.insert(field.ident.as_ref().unwrap(), FieldKind::Result(ok_ty, err_ty));
+                                            continue;
+                                        }
+                                        result.insert(field.ident.as_ref().unwrap(), FieldKind::Unknown);
+                                    }
+                                },
+                                _ => {
+                                    result.insert(field.ident.as_ref().unwrap(), FieldKind::Unknown);
+                                }
+                            }
+                        },
+                        syn::PathArguments::None => {
+                            result.insert(field.ident.as_ref().unwrap(), FieldKind::Primitive(&field.ty));
+                        },
+                        syn::PathArguments::Parenthesized(_) => {
+                            result.insert(field.ident.as_ref().unwrap(), FieldKind::Unknown);
+                        }
+                    }
+                }
+            },
+            syn::Type::Tuple(_) => {
+                result.insert(field.ident.as_ref().unwrap(), FieldKind::Tuple);
+            },
+            _ => {
+                result.insert(field.ident.as_ref().unwrap(), FieldKind::Unknown);
+            }
+        }
+    }
+
+    result
+}

--- a/templatia-derive/src/fields.rs
+++ b/templatia-derive/src/fields.rs
@@ -1,8 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use syn::GenericArgument;
 
-// TODO: Add support for Result<T, E>, Collection<T>, KVCollection<K, V>
-#[allow(dead_code)]
 pub(crate) enum FieldKind<'a> {
     Primitive(&'a syn::Type),
     Option(&'a syn::Type),
@@ -13,7 +11,7 @@ pub(crate) enum FieldKind<'a> {
     HashMap(&'a syn::Type, &'a syn::Type),
     BTreeMap(&'a syn::Type, &'a syn::Type),
     Tuple,
-    Unknown,
+    Unknown ,
 }
 
 pub(crate) struct Fields<'a> {
@@ -28,7 +26,7 @@ impl<'a> Fields<'a> {
         Self { fields, idents_type }
     }
 
-    pub(crate) fn get_type_kind_by_name(&'_ self, name: &str) -> Option<&'_ FieldKind<'_>> {
+    pub(crate) fn get_type_kind_by_name(&'_ self, name: &str) -> Option<&FieldKind<'_>> {
         let name = proc_macro2::Ident::new(name, proc_macro2::Span::call_site());
         self.idents_type.get(&name)
     }
@@ -46,7 +44,7 @@ impl<'a> Fields<'a> {
             .collect::<Vec<_>>()
     }
 
-    pub(crate) fn get_field_kind(&'_ self, ident: &syn::Ident) -> Option<&'_ FieldKind<'_>> {
+    pub(crate) fn get_field_kind(&'_ self, ident: &syn::Ident) -> Option<&FieldKind<'_>> {
         self.idents_type.get(ident)
     }
 
@@ -103,7 +101,7 @@ fn analyze_fields(fields: &'_ [syn::Field]) -> HashMap<&'_ syn::Ident, FieldKind
     let mut result = HashMap::new();
 
     for field in fields {
-        // If the field is not named, skip it. Currently only named fields are supported.
+        // If the field is not named, skip it. Currently, only named fields are supported.
         if field.ident.is_none() {
             continue;
         }
@@ -139,7 +137,7 @@ fn analyze_fields(fields: &'_ [syn::Field]) -> HashMap<&'_ syn::Ident, FieldKind
                                             continue;
                                         }
                                     }
-                                }, 
+                                },
                                 "BTreeSet" => {
                                     if args.args.len() == 1 {
                                         if let Some(GenericArgument::Type(ty)) = args.args.first() {

--- a/templatia-derive/src/inv/error.rs
+++ b/templatia-derive/src/inv/error.rs
@@ -1,4 +1,0 @@
-pub(crate) fn generate_compile_error(msg: &str) -> proc_macro2::TokenStream {
-    let error = syn::Error::new(proc_macro2::Span::call_site(), msg);
-    error.to_compile_error().into()
-}

--- a/templatia-derive/src/inv/error.rs
+++ b/templatia-derive/src/inv/error.rs
@@ -1,0 +1,4 @@
+pub(crate) fn generate_compile_error(msg: &str) -> proc_macro2::TokenStream {
+    let error = syn::Error::new(proc_macro2::Span::call_site(), msg);
+    error.to_compile_error().into()
+}

--- a/templatia-derive/src/inv/mod.rs
+++ b/templatia-derive/src/inv/mod.rs
@@ -1,1 +1,3 @@
 pub(crate) mod parser;
+pub mod generator;
+mod validator;

--- a/templatia-derive/src/inv/mod.rs
+++ b/templatia-derive/src/inv/mod.rs
@@ -1,2 +1,1 @@
 pub(crate) mod parser;
-pub(crate) mod error;

--- a/templatia-derive/src/inv/mod.rs
+++ b/templatia-derive/src/inv/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod parser;
+pub(crate) mod error;

--- a/templatia-derive/src/inv/parser.rs
+++ b/templatia-derive/src/inv/parser.rs
@@ -1,0 +1,237 @@
+use std::collections::HashMap;
+use quote::quote;
+use crate::inv::error::generate_compile_error;
+use crate::fields::{FieldKind, Fields};
+use crate::parser::TemplateSegments;
+use crate::utils::get_type_name;
+
+pub(crate) fn generate_parser_from_segments(
+    struct_name: &syn::Ident,
+    segments: &[TemplateSegments],
+    fields: &Fields,
+    empty_str_as_none: bool,
+    colon_escaper: &proc_macro2::TokenStream,
+) -> proc_macro2::TokenStream {
+    let mut peekable_segments = segments.iter().peekable();
+    let mut parser = quote! { ::templatia::__private::chumsky::prelude::empty() };
+
+    let mut is_first_segment = true;
+    let mut is_passed_first_placeholder = false;
+    let mut latest_segment_was_literal = false;
+
+    let mut literals_counters = HashMap::new();
+    let mut last_literal_parsed: &str = "";
+    let mut last_literal_count: i32 = -1;
+
+    while let Some(segment) = peekable_segments.next() {
+        match segment {
+            TemplateSegments::Literal(lit) => {
+                let count = *literals_counters
+                    .entry(lit)
+                    .and_modify(|count| *count += 1)
+                    .or_insert(1);
+
+                parser = if is_first_segment {
+                    quote! {
+                        just::<&str, &str, chumsky::extra::Err<chumsky::error::Rich<char>>>(#lit)
+                            .ignored()
+                    }
+                } else {
+                    quote! { #parser.then_ignore(just(#lit)) }
+                };
+
+                parser = quote! {
+                    #parser
+                        .map_err(|e| {
+                            let start = match e.found() {
+                                Some(_) => {
+                                    e.span().start
+                                },
+                                None => {
+                                    if #last_literal_count > 0 {
+                                        let found_lit = s.match_indices(#last_literal_parsed).collect::<Vec<_>>();
+                                        // SAFETY: In this branch, the last_literal_count is always 1 or more. So, the #last_literal_count - 1 is always converted to usize.
+                                        // Also, the last_literal_parsed and last_literal_count indicate **last**, so in this branch executed,
+                                        // the last literal is parsed, so the index(last_literal_count - 1) is always less than the length of the s.match_indices(#last_literal_parsed).collect::<Vec<_>>().
+                                        // Therefore, the following code never causes an out-of-range panic.
+                                        let (last_indices, _) = found_lit[(#last_literal_count - 1) as usize];
+                                        last_indices + #last_literal_parsed.len()
+                                    } else {
+                                        0usize
+                                    }
+                                }
+                            };
+
+                            chumsky::error::Rich::<char>::custom(
+                                e.span().clone(),
+                                // SAFETY: The start is 0 or index from the s. Therefore, this isn't an out of range.
+                                format!("__templatia_parse_literal__:{}::{}",
+                                    #lit.#colon_escaper,
+                                    &s[start..].#colon_escaper,
+                                )
+                            )
+                        })
+                };
+
+                latest_segment_was_literal = true;
+                last_literal_parsed = lit;
+                last_literal_count = count;
+            },
+            TemplateSegments::Placeholder(placeholder) => {
+                let name_ident = syn::Ident::new(&placeholder, proc_macro2::Span::call_site());
+
+                // In the internal implementation of the inv::fields::Fields, the placeholder is valid;
+                // then the get_field_kind returns Some.
+                let field_kind = match fields.get_field_kind(&name_ident) {
+                    Some(kind) => kind,
+                    None => return generate_compile_error(
+                        &format!(
+                            "{} has no field named \"{}\"",
+                            struct_name, placeholder
+                        )
+                    )
+                };
+
+
+                let field_parser = generate_field_parser(
+                    &name_ident,
+                    field_kind,
+                    peekable_segments.peek().cloned(),
+                    empty_str_as_none,
+                    colon_escaper,
+                );
+
+                if is_first_segment {
+                    parser = field_parser;
+                } else if !is_passed_first_placeholder && latest_segment_was_literal {
+                    parser = quote! { #parser.ignore_then(#field_parser) };
+                } else {
+                    parser = quote! { #parser.then(#field_parser) };
+                }
+
+                is_passed_first_placeholder = true;
+                latest_segment_was_literal = false;
+            }
+        }
+        is_first_segment = false;
+    }
+
+    quote! { #parser.then_ignore(end()) }
+}
+
+fn generate_field_parser(
+    field_name: &syn::Ident,
+    field_type: &FieldKind,
+    next_segment: Option<&TemplateSegments>,
+    empty_str_as_none: bool,
+    colon_escaper: &proc_macro2::TokenStream,
+) -> proc_macro2::TokenStream {
+    let next_literal = match next_segment {
+        Some(TemplateSegments::Literal(lit)) => Some(*lit),
+        _ => None,
+    };
+
+    match field_type {
+        FieldKind::Option(ty) => {
+            let is_string_type = matches!(
+                get_type_name(ty).to_lowercase().as_str(),
+                "string" | "str"
+            );
+            let inner_parser = generate_parser(ty, next_literal);
+
+            quote! {
+                #inner_parser
+                    .try_map(|s: &str, span| {
+                        if (#empty_str_as_none || !#is_string_type) && s.is_empty() {
+                            Ok(None)
+                        } else {
+                            s.parse::<#ty>()
+                                .map(Some)
+                                .map_err(|_| {
+                                    let op_type = format!("Option<{}>", stringify!(#ty));
+
+                                    chumsky::error::Rich::<char>::custom(
+                                        span,
+                                        format!(
+                                            "__templatia_parse_type__:{}::{}::{}",
+                                            stringify!(#field_name).#colon_escaper,
+                                            s.#colon_escaper,
+                                            op_type.#colon_escaper,
+                                        )
+                                    )
+                                })
+                        }
+                    })
+            }
+        },
+        FieldKind::Primitive(ty) => {
+            let parser = generate_parser(ty, next_literal);
+
+            quote! {
+                #parser
+                    .try_map(|s: &str, span| {
+                        s.parse::<#ty>()
+                            .map_err(|_| {
+                                chumsky::error::Rich::<char>::custom(
+                                    span,
+                                    format!(
+                                        "__templatia_parse_type__:{}::{}::{}",
+                                        stringify!(#field_name).#colon_escaper,
+                                        s.#colon_escaper,
+                                        stringify!(#ty).#colon_escaper,
+                                    )
+                                )
+                            })
+                    })
+            }
+        },
+        _ => {
+            let error = syn::Error::new(
+                proc_macro2::Span::call_site(),
+                format!(
+                    "{} is currently not supported",
+                    field_name.to_string(),
+                )
+            );
+
+            error.to_compile_error().into()
+        }
+    }
+}
+
+fn generate_parser(
+    field_type: &syn::Type,
+    next_literal: Option<&str>,
+) -> proc_macro2::TokenStream {
+    let base_parser = if let Some(next_lit) = next_literal {
+        quote! {
+            just::<&str, &str, chumsky::extra::Err<chumsky::error::Rich<char>>>(#next_lit)
+                .not()
+                .ignore_then(any())
+                .repeated()
+        }
+    } else {
+        quote! {
+            any::<&str, chumsky::extra::Err<chumsky::error::Rich<char>>>()
+                .repeated()
+        }
+    };
+
+    match get_type_name(field_type).as_str() {
+        "char" => quote! {
+            any::<&str, chumsky::extra::Err<chumsky::error::Rich<char>>>()
+                .map(|c| c.to_string())
+                .to_slice()
+        },
+        "bool" => quote! {
+            choice((
+                just::<&str, &str, chumsky::extra::Err<chumsky::error::Rich<char>>>("true").to_slice(),
+                just::<&str, &str, chumsky::extra::Err<chumsky::error::Rich<char>>>("false").to_slice(),
+                #base_parser.at_most(5).to_slice(),
+            ))
+        },
+        _ => quote! {
+            #base_parser.to_slice()
+        }
+    }
+}

--- a/templatia-derive/src/inv/parser.rs
+++ b/templatia-derive/src/inv/parser.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use quote::quote;
-use crate::inv::error::generate_compile_error;
+use crate::error::{generate_compile_error, generate_unsupported_compile_error};
 use crate::fields::{FieldKind, Fields};
 use crate::parser::TemplateSegments;
 use crate::utils::get_type_name;
@@ -186,15 +186,7 @@ fn generate_field_parser(
             }
         },
         _ => {
-            let error = syn::Error::new(
-                proc_macro2::Span::call_site(),
-                format!(
-                    "{} is currently not supported",
-                    field_name.to_string(),
-                )
-            );
-
-            error.to_compile_error().into()
+            generate_unsupported_compile_error(field_name, field_type)
         }
     }
 }

--- a/templatia-derive/src/lib.rs
+++ b/templatia-derive/src/lib.rs
@@ -26,16 +26,14 @@
 //!
 //! For detailed usage examples and comprehensive documentation, see the main `templatia` crate.
 
-mod generator;
 mod parser;
-mod validator;
 mod utils;
 mod inv;
 pub(crate) mod fields;
 mod render;
 pub(crate) mod error;
 
-use crate::generator::generate_str_parser;
+use inv::generator::generate_str_parser;
 use crate::parser::{parse_template, TemplateSegments};
 use darling::FromDeriveInput;
 use darling::util::{Flag, Override};

--- a/templatia-derive/src/lib.rs
+++ b/templatia-derive/src/lib.rs
@@ -30,16 +30,20 @@ mod generator;
 mod parser;
 mod validator;
 mod utils;
+mod inv;
+pub(crate) mod fields;
+mod render;
 
 use crate::generator::generate_str_parser;
-use crate::parser::{TemplateSegments, parse_template};
-use darling::{FromDeriveInput};
+use crate::parser::{parse_template, TemplateSegments};
+use darling::FromDeriveInput;
 use darling::util::{Flag, Override};
 use proc_macro::TokenStream;
 use quote::quote;
 use std::collections::HashSet;
-use syn::{DeriveInput, parse_macro_input};
-use crate::utils::get_inner_type_from_option;
+use syn::{parse_macro_input, DeriveInput};
+use crate::fields::{FieldKind, Fields};
+use crate::render::generate_format_string_args;
 
 #[derive(Debug, FromDeriveInput)]
 #[darling(attributes(templatia), supports(struct_named))]
@@ -129,10 +133,12 @@ pub fn template_derive(input: TokenStream) -> TokenStream {
         unreachable!()
     };
 
-    let optional_fields = all_fields
+    let fields = Fields::new(all_fields);
+    
+    let option_fields = fields
+        .option_fields()
         .iter()
-        .filter(|f| get_inner_type_from_option(&f.ty).is_some())
-        .filter_map(|f| f.ident.as_ref())
+        .map(|(ident, _)| *ident)
         .collect::<HashSet<_>>();
 
     let segments = match parse_template(&template) {
@@ -145,29 +151,7 @@ pub fn template_derive(input: TokenStream) -> TokenStream {
         }
     };
 
-    // Generate format string like "key = {}, key2 = {}"
-    let format_string = segments
-        .iter()
-        .map(|segment| match segment {
-            TemplateSegments::Literal(lit) => lit.replace("{", "{{").replace("}", "}}"),
-            TemplateSegments::Placeholder(_) => "{}".to_string(),
-        })
-        // This collect works because the String implements FromIterator.
-        .collect::<String>();
-
-    // Generate code for placeholder completion the format_string it used the self keys
-    let format_args = segments.iter().filter_map(|segment| match segment {
-        TemplateSegments::Placeholder(name) => {
-            let field_ident =  syn::Ident::new(name, proc_macro2::Span::call_site());
-
-            if optional_fields.contains(&field_ident) {
-                Some(quote! { &self.#field_ident.as_ref().map(|v| v.to_string()).unwrap_or("".to_string()) })
-            } else {
-                Some(quote! { &self.#field_ident })
-            }
-        }
-        TemplateSegments::Literal(_) => None,
-    });
+    let (format_string, format_args) = generate_format_string_args(&segments, &option_fields);
 
     // Gathering the all placeholder name without duplication
     let placeholder_names = segments
@@ -183,7 +167,7 @@ pub fn template_derive(input: TokenStream) -> TokenStream {
 
     let str_from_parser = generate_str_parser(
         name,
-        all_fields,
+        &fields,
         &placeholder_names,
         &segments,
         allow_missing_placeholders,
@@ -194,48 +178,42 @@ pub fn template_derive(input: TokenStream) -> TokenStream {
     // Generate trait bound
     let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
 
-    let used_fields = all_fields
-        .iter()
-        .filter(|field| {
-            if let Some(ident) = &field.ident {
-                placeholder_names.contains(&ident.to_string())
-            } else {
-                false
-            }
-        })
-        .collect::<Vec<_>>();
-
     let mut new_where_clause = where_clause
         .cloned()
         .unwrap_or_else(|| syn::parse_quote! { where });
 
-    for field in used_fields {
-        let field_ty = &field.ty;
+    for field in fields.used_fields_in_template(&placeholder_names) {
         if !new_where_clause.predicates.is_empty() {
             // push_punct adds a comma between predicates.
             new_where_clause.predicates.push_punct(Default::default());
         }
-
-        if let Some(inner_type) = get_inner_type_from_option(field_ty) {
-            new_where_clause.predicates.push(syn::parse_quote! {
-                #inner_type: ::std::fmt::Display + ::std::str::FromStr + ::std::cmp::PartialEq
-            });
-            new_where_clause.predicates.push(syn::parse_quote! {
-                <#inner_type as ::std::str::FromStr>::Err: ::std::fmt::Display
-            });
-        } else {
-            if !allow_missing_placeholders {
-                new_where_clause.predicates.push(syn::parse_quote! {
-                    #field_ty: ::std::fmt::Display + ::std::str::FromStr + ::std::cmp::PartialEq
-                });
-            } else {
-                new_where_clause.predicates.push(syn::parse_quote! {
-                    #field_ty: ::std::fmt::Display + ::std::str::FromStr + ::std::cmp::PartialEq + ::std::default::Default
-                });
+        
+        if let Some(ident) = field.ident.as_ref() {
+            match fields.get_field_kind(ident) {
+                Some(FieldKind::Option(ty)) => {
+                    new_where_clause.predicates.push(syn::parse_quote! {
+                        #ty: ::std::fmt::Display + ::std::str::FromStr + ::std::cmp::PartialEq
+                    });
+                            new_where_clause.predicates.push(syn::parse_quote! {
+                        <#ty as ::std::str::FromStr>::Err: ::std::fmt::Display
+                    });
+                },
+                Some(FieldKind::Primitive(ty)) => {
+                    if !allow_missing_placeholders {
+                        new_where_clause.predicates.push(syn::parse_quote! {
+                            #ty: ::std::fmt::Display + ::std::str::FromStr + ::std::cmp::PartialEq
+                        });
+                    } else {
+                        new_where_clause.predicates.push(syn::parse_quote! {
+                            #ty: ::std::fmt::Display + ::std::str::FromStr + ::std::cmp::PartialEq + ::std::default::Default
+                        });
+                    }
+                    new_where_clause.predicates.push(syn::parse_quote! {
+                        <#ty as ::std::str::FromStr>::Err: ::std::fmt::Display
+                    });
+                },
+                _ => return syn::Error::new_spanned(field, "Unsupported field type").to_compile_error().into(),
             }
-            new_where_clause.predicates.push(syn::parse_quote! {
-                <#field_ty as ::std::str::FromStr>::Err: ::std::fmt::Display
-            });
         }
     }
 
@@ -256,7 +234,9 @@ pub fn template_derive(input: TokenStream) -> TokenStream {
             }
 
             fn from_str(s: &str) -> Result<Self, Self::Error> {
+                use ::templatia::__private::chumsky;
                 use ::templatia::__private::chumsky::Parser;
+                use ::templatia::__private::chumsky::prelude::*;
 
                 let parser = #str_from_parser;
                 match parser.parse(s).into_result() {

--- a/templatia-derive/src/lib.rs
+++ b/templatia-derive/src/lib.rs
@@ -33,6 +33,7 @@ mod utils;
 mod inv;
 pub(crate) mod fields;
 mod render;
+pub(crate) mod error;
 
 use crate::generator::generate_str_parser;
 use crate::parser::{parse_template, TemplateSegments};
@@ -42,6 +43,7 @@ use proc_macro::TokenStream;
 use quote::quote;
 use std::collections::HashSet;
 use syn::{parse_macro_input, DeriveInput};
+use crate::error::generate_unsupported_compile_error;
 use crate::fields::{FieldKind, Fields};
 use crate::render::generate_format_string_args;
 
@@ -212,7 +214,8 @@ pub fn template_derive(input: TokenStream) -> TokenStream {
                         <#ty as ::std::str::FromStr>::Err: ::std::fmt::Display
                     });
                 },
-                _ => return syn::Error::new_spanned(field, "Unsupported field type").to_compile_error().into(),
+                Some(kind) => return generate_unsupported_compile_error(ident, kind).into(),
+                None => return generate_unsupported_compile_error(ident, &FieldKind::Unknown).into(),
             }
         }
     }

--- a/templatia-derive/src/render.rs
+++ b/templatia-derive/src/render.rs
@@ -1,0 +1,46 @@
+use std::collections::HashSet;
+use proc_macro2::TokenStream;
+use quote::quote;
+use crate::parser::TemplateSegments;
+
+pub(super) fn generate_format_string_args(
+    segments: &[TemplateSegments<'_>],
+    option_fields: &HashSet<&syn::Ident>,
+) -> (String, Vec<TokenStream>)
+{
+    // Generate format string like "key = {}, key2 = {}"
+    let format_string = segments
+        .iter()
+        .map(|segment| match segment {
+            TemplateSegments::Literal(lit) => lit.replace("{", "{{").replace("}", "}}"),
+            TemplateSegments::Placeholder(_) => "{}".to_string(),
+        })
+        // This collect works because the String implements FromIterator.
+        .collect::<String>();
+
+    // Generate code for placeholder completion the format_string it used the self keys
+    let format_args = segments
+        .iter()
+        .filter_map(|segment| match segment {
+            TemplateSegments::Placeholder(name) => {
+                let field_ident = syn::Ident::new(name, proc_macro2::Span::call_site());
+
+                // &self.#field_ident means the field of the struct named `field_ident`
+                // If the struct is
+                // ```rust
+                // struct Point { x: i32, y: i32 }
+                // ```
+                // then the field_ident is `x` or `y`.
+                // The token stream indicates &self.x or &self.y.
+                // Please note: the #field_ident is not `field_ident` but `x` or `y`.
+                if option_fields.contains(&&field_ident) {
+                    Some( quote! { &self.#field_ident.as_ref().map(|v| v.to_string()).unwrap_or("".to_string()) } )
+                } else {
+                    Some( quote! { &self.#field_ident } )
+                }
+            },
+            TemplateSegments::Literal(_) => None,
+        }).collect::<Vec<_>>();
+
+    (format_string, format_args)
+}

--- a/templatia-derive/src/utils.rs
+++ b/templatia-derive/src/utils.rs
@@ -19,9 +19,9 @@ pub(crate) fn get_type_name(ty: &syn::Type) -> String {
             if let Some(ident) = &path.path.get_ident() {
                 ident.to_string()
             } else {
-                "unknown_type".to_string()
+                "cannot_recognized".to_string()
             }
         },
-        _ => "unknown_type".to_string(),
+        _ => "cannot_recognized".to_string(),
     }
 }

--- a/templatia-derive/src/utils.rs
+++ b/templatia-derive/src/utils.rs
@@ -1,6 +1,3 @@
-use syn::GenericArgument;
-use syn::punctuated::Punctuated;
-
 pub(crate) const CONSECUTIVE_PLACEHOLDER_ALLOWED_TYPE: [&str; 2] = ["char", "bool"];
 
 pub(crate) fn is_allowed_consecutive_allowed_type(field_type: &syn::Type) -> bool {
@@ -16,15 +13,6 @@ pub(crate) fn is_allowed_consecutive_allowed_type(field_type: &syn::Type) -> boo
     }
 }
 
-pub(crate) fn get_field_type_by_name<'a>(field_name: &str, all_fields: &'a [syn::Field]) -> Option<&'a syn::Type> {
-    all_fields
-        .iter()
-        .find(|field| {
-            field.ident.as_ref().map(|ident| ident.to_string()) == Some(field_name.to_string())
-        })
-        .map(|field| &field.ty)
-}
-
 pub(crate) fn get_type_name(ty: &syn::Type) -> String {
     match ty {
         syn::Type::Path(path) => {
@@ -36,36 +24,4 @@ pub(crate) fn get_type_name(ty: &syn::Type) -> String {
         },
         _ => "unknown_type".to_string(),
     }
-}
-
-// Extracts the inner type from Option<T> to Option<&syn::Type = T>
-pub(crate) fn get_inner_type_from_option(ty: &syn::Type) -> Option<&syn::Type> {
-    if let Some((ident, punctuated_comma)) = get_inner_type_from_generic(ty) {
-        if ident == "Option" {
-            // Validating that the Option has only one generic argument
-            if punctuated_comma.len() == 1 {
-                if let Some(GenericArgument::Type(ty)) = punctuated_comma.first() {
-                    return Some(ty);
-                }
-            }
-        }
-    }
-    None
-}
-
-/// Gets the inner type from a generic type like Option<T> or Vec<T>
-/// Returns the last segment of the path and the generic arguments
-fn get_inner_type_from_generic(ty: &syn::Type) -> Option<(&syn::Ident, &Punctuated<GenericArgument, syn::Token![,]>)> {
-    // The type needs to be a Type::Path variant. Path variants are used for named paths.
-    if let syn::Type::Path(type_path) = ty {
-        // Getting the last segment of the path,
-        // This is robust for such as std::option::Option which has multiple segments
-        if let Some(last_segment) = type_path.path.segments.last() {
-            // Getting the generic arguments of the last segment.
-            if let syn::PathArguments::AngleBracketed(args) = &last_segment.arguments {
-                return Some((&last_segment.ident, &args.args));
-            }
-        }
-    }
-    None
 }

--- a/templatia-derive/src/validator.rs
+++ b/templatia-derive/src/validator.rs
@@ -1,21 +1,20 @@
+use crate::fields::{FieldKind, Fields};
 use crate::parser::TemplateSegments;
-use crate::utils::{get_field_type_by_name, get_inner_type_from_option, get_type_name, is_allowed_consecutive_allowed_type, CONSECUTIVE_PLACEHOLDER_ALLOWED_TYPE};
+use crate::utils::{get_type_name, is_allowed_consecutive_allowed_type, CONSECUTIVE_PLACEHOLDER_ALLOWED_TYPE};
 
 pub(crate) fn validate_template_safety(
     segments: &[TemplateSegments],
-    all_fields: &[syn::Field],
+    fields: &Fields,
 ) -> Result<(), String> {
     for window in segments.windows(2) {
         if let [TemplateSegments::Placeholder(first), TemplateSegments::Placeholder(second)] = window {
-            let first_type = get_field_type_by_name(first, all_fields);
-
+            let first_type = fields.get_type_kind_by_name(first);
             let (allowed_consecutive, first_type_name) = match first_type {
-                Some(first_ty) => {
-                    if let Some(ty) = get_inner_type_from_option(first_ty) {
-                        (is_allowed_consecutive_allowed_type(ty), format!("Option<{}>", get_type_name(ty)))
-                    } else {
-                        (is_allowed_consecutive_allowed_type(first_ty), get_type_name(first_ty))
-                    }
+                Some(FieldKind::Option(ty)) => {
+                    (is_allowed_consecutive_allowed_type(ty), format!("Option<{}>", get_type_name(ty)))
+                },
+                Some(FieldKind::Primitive(ty)) => {
+                    (is_allowed_consecutive_allowed_type(ty), get_type_name(ty))
                 },
                 _ => (false, "unknown_type".to_string()),
             };

--- a/templatia-derive/tests/compile_fail/consecutive_disallowed.rs
+++ b/templatia-derive/tests/compile_fail/consecutive_disallowed.rs
@@ -1,0 +1,8 @@
+use templatia::Template;
+
+#[derive(Template)]
+#[templatia(template = "{first}{second}")]
+struct BadConsecutive {
+    first: String,
+    second: String,
+}

--- a/templatia-derive/tests/compile_fail/consecutive_disallowed.stderr
+++ b/templatia-derive/tests/compile_fail/consecutive_disallowed.stderr
@@ -1,4 +1,4 @@
-error: BadConsecutive: Placeholder "first" and "second" are consecutive. These are ambiguous to parsing.
+error: placeholder "first" and "second" are consecutive. these cause ambiguity to parsing bound.
        "first" is `String` type data. Consecutive allows only: [char, bool]
  --> tests/compile_fail/consecutive_disallowed.rs:3:10
   |

--- a/templatia-derive/tests/compile_fail/consecutive_disallowed.stderr
+++ b/templatia-derive/tests/compile_fail/consecutive_disallowed.stderr
@@ -1,0 +1,14 @@
+error: BadConsecutive: Placeholder "first" and "second" are consecutive. These are ambiguous to parsing.
+       "first" is `String` type data. Consecutive allows only: [char, bool]
+ --> tests/compile_fail/consecutive_disallowed.rs:3:10
+  |
+3 | #[derive(Template)]
+  |          ^^^^^^^^
+  |
+  = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0601]: `main` function not found in crate `$CRATE`
+ --> tests/compile_fail/consecutive_disallowed.rs:8:2
+  |
+8 | }
+  |  ^ consider adding a `main` function to `$DIR/tests/compile_fail/consecutive_disallowed.rs`

--- a/templatia-derive/tests/compile_fail/unsupported_collection.rs
+++ b/templatia-derive/tests/compile_fail/unsupported_collection.rs
@@ -1,0 +1,7 @@
+use templatia::Template;
+
+#[derive(Template)]
+#[templatia(template = "items={items}")]
+struct HasCollection {
+    items: Vec<String>,
+}

--- a/templatia-derive/tests/compile_fail/unsupported_collection.stderr
+++ b/templatia-derive/tests/compile_fail/unsupported_collection.stderr
@@ -1,0 +1,13 @@
+error: unsupported type field: items has a Vec<String> type. currently, Vec<String> is not supported.
+ --> tests/compile_fail/unsupported_collection.rs:3:10
+  |
+3 | #[derive(Template)]
+  |          ^^^^^^^^
+  |
+  = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0601]: `main` function not found in crate `$CRATE`
+ --> tests/compile_fail/unsupported_collection.rs:7:2
+  |
+7 | }
+  |  ^ consider adding a `main` function to `$DIR/tests/compile_fail/unsupported_collection.rs`

--- a/templatia-derive/tests/compile_fail/unsupported_collection.stderr
+++ b/templatia-derive/tests/compile_fail/unsupported_collection.stderr
@@ -1,4 +1,4 @@
-error: unsupported type field: items has a Vec<String> type. currently, Vec<String> is not supported.
+error: unsupported type field: items has a Vec<String> type. currently, Vec<String> is not supported
  --> tests/compile_fail/unsupported_collection.rs:3:10
   |
 3 | #[derive(Template)]

--- a/templatia-derive/tests/compile_fail/unsupported_map.rs
+++ b/templatia-derive/tests/compile_fail/unsupported_map.rs
@@ -1,0 +1,8 @@
+use std::collections::HashMap;
+use templatia::Template;
+
+#[derive(Template)]
+#[templatia(template = "map={map}")]
+struct HasMap {
+    map: HashMap<String, i32>,
+}

--- a/templatia-derive/tests/compile_fail/unsupported_map.stderr
+++ b/templatia-derive/tests/compile_fail/unsupported_map.stderr
@@ -1,4 +1,4 @@
-error: unsupported type field: map has a HashMap<String, i32> type. currently, HashMap<String, i32> is not supported.
+error: unsupported type field: map has a HashMap<String, i32> type. currently, HashMap<String, i32> is not supported
  --> tests/compile_fail/unsupported_map.rs:4:10
   |
 4 | #[derive(Template)]

--- a/templatia-derive/tests/compile_fail/unsupported_map.stderr
+++ b/templatia-derive/tests/compile_fail/unsupported_map.stderr
@@ -1,0 +1,13 @@
+error: unsupported type field: map has a HashMap<String, i32> type. currently, HashMap<String, i32> is not supported.
+ --> tests/compile_fail/unsupported_map.rs:4:10
+  |
+4 | #[derive(Template)]
+  |          ^^^^^^^^
+  |
+  = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0601]: `main` function not found in crate `$CRATE`
+ --> tests/compile_fail/unsupported_map.rs:8:2
+  |
+8 | }
+  |  ^ consider adding a `main` function to `$DIR/tests/compile_fail/unsupported_map.rs`

--- a/templatia-derive/tests/compile_fail/unsupported_result.rs
+++ b/templatia-derive/tests/compile_fail/unsupported_result.rs
@@ -1,0 +1,7 @@
+use templatia::Template;
+
+#[derive(Template)]
+#[templatia(template = "res={res}")]
+struct HasResult {
+    res: Result<i32, String>,
+}

--- a/templatia-derive/tests/compile_fail/unsupported_result.stderr
+++ b/templatia-derive/tests/compile_fail/unsupported_result.stderr
@@ -1,0 +1,13 @@
+error: unsupported type field: res has a Result<i32, String> type. currently, Result<i32, String> is not supported.
+ --> tests/compile_fail/unsupported_result.rs:3:10
+  |
+3 | #[derive(Template)]
+  |          ^^^^^^^^
+  |
+  = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0601]: `main` function not found in crate `$CRATE`
+ --> tests/compile_fail/unsupported_result.rs:7:2
+  |
+7 | }
+  |  ^ consider adding a `main` function to `$DIR/tests/compile_fail/unsupported_result.rs`

--- a/templatia-derive/tests/compile_fail/unsupported_result.stderr
+++ b/templatia-derive/tests/compile_fail/unsupported_result.stderr
@@ -1,4 +1,4 @@
-error: unsupported type field: res has a Result<i32, String> type. currently, Result<i32, String> is not supported.
+error: unsupported type field: res has a Result<i32, String> type. currently, Result<i32, String> is not supported
  --> tests/compile_fail/unsupported_result.rs:3:10
   |
 3 | #[derive(Template)]

--- a/templatia-derive/tests/compile_fail/unsupported_tuple.rs
+++ b/templatia-derive/tests/compile_fail/unsupported_tuple.rs
@@ -1,0 +1,7 @@
+use templatia::Template;
+
+#[derive(Template)]
+#[templatia(template = "vals={vals}")]
+struct HasTuple {
+    vals: (i32, i32),
+}

--- a/templatia-derive/tests/compile_fail/unsupported_tuple.stderr
+++ b/templatia-derive/tests/compile_fail/unsupported_tuple.stderr
@@ -1,4 +1,4 @@
-error: unsupported type field: vals has a tuple type. currently, tuple is not supported.
+error: unsupported type field: vals has a tuple type. currently, tuple is not supported
  --> tests/compile_fail/unsupported_tuple.rs:3:10
   |
 3 | #[derive(Template)]

--- a/templatia-derive/tests/compile_fail/unsupported_tuple.stderr
+++ b/templatia-derive/tests/compile_fail/unsupported_tuple.stderr
@@ -1,0 +1,13 @@
+error: unsupported type field: vals has a tuple type. currently, tuple is not supported.
+ --> tests/compile_fail/unsupported_tuple.rs:3:10
+  |
+3 | #[derive(Template)]
+  |          ^^^^^^^^
+  |
+  = note: this error originates in the derive macro `Template` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0601]: `main` function not found in crate `$CRATE`
+ --> tests/compile_fail/unsupported_tuple.rs:7:2
+  |
+7 | }
+  |  ^ consider adding a `main` function to `$DIR/tests/compile_fail/unsupported_tuple.rs`

--- a/templatia/Cargo.toml
+++ b/templatia/Cargo.toml
@@ -16,7 +16,7 @@ documentation = { workspace = true }
 [dependencies]
 thiserror = "2"
 
-templatia-derive = { version = "0.0.2", path = "../templatia-derive", optional = true }
+templatia-derive = { version = "0.0.3", path = "../templatia-derive", optional = true }
 chumsky = { version = "0.11", optional = true }
 
 [features]

--- a/templatia/src/lib.rs
+++ b/templatia/src/lib.rs
@@ -17,7 +17,7 @@
 //! Add templatia to your `Cargo.toml`:
 //! ```toml
 //! [dependencies]
-//! templatia = { version = "0.0.1", features = ["derive"] }
+//! templatia = { version = "0.0.3", features = ["derive"] }
 //! ```
 //!
 //! ### Using the Derive Macro (Recommended)


### PR DESCRIPTION
- Extract `fields`, `render`, and `inv` logic into dedicated modules for clarity
- Remove unused utility functions: `get_field_type_by_name` and `get_inner_type_from_option`
- Integrate `Fields` abstraction into validator and generator for improved field handling
- Add detailed error messages for unsupported field types, including tuples, Vec, Result, collections, and maps
- Replace redundant error generation with `generate_unsupported_compile_error` function
- Update `fields` module to distinguish between specific collection types clearly
- Add new compile-fail tests to validate error messages for unsupported types
- Introduce new error generation functions: `generate_consecutive_compile_error` and `generate_not_found_placeholder_compile_error`
- Improve error messages for clarity and consistency across unsupported cases
- Reorganize internal modules: move `generator` and `validator` under `inv` module
- Update crate version to `0.0.3` and adjust dependency references accordingly
- Refactor `Fields` and `validator` logic for better type handling and validation